### PR TITLE
헤더 수정(모바일 완)

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -19,7 +19,7 @@ function Dropdown(props: PropsType) {
       <div className={`grid place-items-center`}>{defaultLabel}</div>
       {isHovering && (
         <ul
-          className={`top-full absolute min-w-max mt-3 overflow-hidden ${listContainerStyle}`}
+          className={`top-full absolute min-w-max pt-3 overflow-hidden ${listContainerStyle}`}
         >
           <li
             className={`py-7 px-10 flex flex-col-center gap-7 bg-white ${isHovering ? 'animate-dropdown' : ''}`}

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -2,19 +2,17 @@ import UserLogin from '@/assets/icons/user-login.svg?react';
 
 function HeaderButtons() {
   const btnStyle =
-    'w-[100px] h-[36px] px-20 py-4 flex-row-center rounded-[20px] text-14';
+    'w-100 h-36 px-20 py-4 flex-row-center rounded-[20px] text-14';
 
   return (
     <div className={'flex flex-col items-center sm:flex-row gap-10'}>
       <button
-        className={
-          'hidden sm:flex w-[100px] h-[36px] text-14 items-center gap-4'
-        }
+        className={'hidden sm:flex w-100 h-36 text-14 items-center gap-4'}
       >
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-[64px] h-[36px] flex-row-center text-14 font-semibold text-primary-400'
+            'w-64 h-36 flex-row-center text-14 font-semibold text-primary-400'
           }
         >
           로그인

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -1,13 +1,30 @@
+import { useState } from 'react';
+
 import UserLogin from '@/assets/icons/user-login.svg?react';
+import AuthModal from '@/components/Header/AuthModal';
+import useModal from '@/hooks/useModal';
+import { AuthModalType } from '@/types/auth';
 
 function HeaderButtons() {
   const btnStyle =
     'w-100 h-36 px-20 py-4 flex-row-center rounded-[20px] text-14';
+  const { isVisible, toggleModal } = useModal();
+  const [modalType, setModalType] = useState<AuthModalType>('login');
+
+  const handleClick = (type: AuthModalType) => {
+    toggleModal();
+    setModalType(type);
+  };
+
+  const toggleModalType = () => {
+    setModalType(modalType === 'login' ? 'register' : 'login');
+  };
 
   return (
     <div className={'flex flex-col items-center sm:flex-row gap-10'}>
       <button
         className={'hidden sm:flex w-100 h-36 text-14 items-center gap-4'}
+        onClick={() => handleClick('login')}
       >
         <UserLogin className={'w-30 h-30'} />
         <div
@@ -18,12 +35,24 @@ function HeaderButtons() {
           로그인
         </div>
       </button>
-      <button className={`block sm:hidden ${btnStyle} btn-white-pb`}>
+      <button
+        className={`block sm:hidden ${btnStyle} btn-white-pb`}
+        onClick={() => handleClick('login')}
+      >
         로그인
       </button>
-      <button className={`${btnStyle} bg-primary-400 text-white`}>
+      <button
+        className={`${btnStyle} bg-primary-400 text-white`}
+        onClick={() => handleClick('register')}
+      >
         회원가입
       </button>
+      <AuthModal
+        type={modalType}
+        isVisible={isVisible}
+        onClose={toggleModal}
+        onToggle={toggleModalType}
+      />
     </div>
   );
 }

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -1,5 +1,5 @@
-import HeaderButtons from '@/components/Header/HeaderButtons';
-import HeaderNav from '@/components/Header/HeaderNav';
+import HeaderButtons from './HeaderButtons';
+import HeaderNav from './HeaderNav';
 
 function HeaderMenu() {
   return (

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
 import MenuIcon from '@/assets/icons/menu.svg?react';
-import MobileNav from '@/components/Header/MobileNav';
+
+import MobileNav from './MobileNav';
 
 function MobileMenu() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -24,7 +25,7 @@ function MobileMenu() {
       <div>
         <div className={'grid place-items-center'}>
           <MenuIcon
-            className={'w-[32px] h-[32px]'}
+            className={'w-32 h-32'}
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           />
         </div>

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router-dom';
 
-import HeaderButtons from '@/components/Header/HeaderButtons';
 import { mobileMenuNavItems } from '@/constants/navItems';
 import { MobileMenuNavItem } from '@/types/navTypes';
+
+import HeaderButtons from './HeaderButtons';
 
 function MobileNav() {
   return (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ function Header() {
   return (
     <header
       className={
-        'top-0 mt-[51px] sm:mt-0 sticky sm:fixed w-full h-36 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
+        'fixed w-full h-114 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 pt-61 pb-17 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
       }
     >
       <Link to={'/'} className={'flex items-center'}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ function Header() {
   return (
     <header
       className={
-        'top-0 fixed w-full h-114 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 pt-61 pb-17 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
+        'top-0 fixed w-full h-70 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 py-17 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
       }
     >
       <Link to={'/'} className={'flex items-center'}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ function Header() {
   return (
     <header
       className={
-        'fixed w-full h-114 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 pt-61 pb-17 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
+        'top-0 fixed w-full h-114 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 pt-61 pb-17 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
       }
     >
       <Link to={'/'} className={'flex items-center'}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,14 +1,15 @@
 import { Link } from 'react-router-dom';
 
 import logo from '@/assets/icons/logo.png';
-import HeaderMenu from '@/components/Header/HeaderMenu';
-import MobileMenu from '@/components/Header/MobileMenu';
+
+import HeaderMenu from './HeaderMenu';
+import MobileMenu from './MobileMenu';
 
 function Header() {
   return (
     <header
       className={
-        'top-0 mt-[51px] sm:mt-0 sticky sm:fixed w-full h-[36px] sm:h-[100px] pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
+        'top-0 mt-[51px] sm:mt-0 sticky sm:fixed w-full h-36 sm:h-100 pl-26 pr-17 sm:px-43 md:px-73 lg:px-103 sm:pt-22 sm:pb-10 flex justify-between items-center sm:flex-col sm:items-stretch bg-white z-10'
       }
     >
       <Link to={'/'} className={'flex items-center'}>

--- a/src/constants/navItems.ts
+++ b/src/constants/navItems.ts
@@ -58,12 +58,12 @@ export const headerNavItems: HeaderNavItem[] = [
   },
   {
     type: 'link',
-    to: '/contact',
+    to: '/assignment',
     text: '과제',
   },
   {
     type: 'link',
-    to: '/contact',
+    to: '/survey',
     text: '설문',
   },
 ];


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

- 모바일 화면 헤더 수정
- 모달 다시 추가

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 제가 실수로 지웠던 모달 부분 다시 추가했습니다.
- 모바일 뷰 헤더

https://github.com/user-attachments/assets/3afa7285-df91-42c3-85bd-1ced238949de

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->

- z 인덱스 문제 확인부탁드립니다. 헤더가 홈 본문에 가려져서 z-10을 줬는데 그렇게 하면 모달이 켜질때 백드롭이 늦게 적용되는 문제가 생기네요.
- 그래서 헤더의 z-index는 기본값으로 두고 Layout 에서 본문에 z 인덱스 -1 주면 해결되긴 하는데 이렇게 해도 될까요?

https://github.com/user-attachments/assets/a22dcd0e-8fc7-4578-a3e1-6140abd76c27

https://github.com/user-attachments/assets/46e17db7-2ef3-4ed7-bc67-003f8dfb516f

