### PR TITLE
feat: 마이페이지 퍼블리싱

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import { Navigate } from 'react-router-dom';
+
+export default function PrivateRoute({ children }: PropsWithChildren) {
+  // TODO: 로그인 확인
+  const isLoggedIn = true; // 임시
+  return isLoggedIn ? children : <Navigate to='/' replace />;
+}

--- a/src/pages/My/components/EditAccount.tsx
+++ b/src/pages/My/components/EditAccount.tsx
@@ -2,21 +2,26 @@ import { X } from '@phosphor-icons/react';
 
 import Modal from '@/components/Modal';
 
-import { AccountEditProps } from '../types';
+import { ProfileEditProps } from '../types';
 
-export default function EditAccount({ onToggle }: AccountEditProps) {
+export default function EditAccount({ onClose, onToggle }: ProfileEditProps) {
   const fieldStyle = 'flex flex-col focus-within:text-primary-300 transition-2';
   const inputStyle =
     'px-0 py-4 rounded-none border-b-1 border-zinc-300 border-neutral-500 focus:border-primary-300 text-neutral-600 transition-2';
 
+  const handleClose = () => {
+    onClose();
+    onToggle(); // 프로필 수정 모달로 초기화
+  };
+
   return (
     <>
       <Modal.Content>
-        <div className='px-16 pb-16'>
+        <div className='px-16'>
           <button
             type='button'
             className='absolute top-12 right-12'
-            onClick={onToggle}
+            onClick={handleClose}
           >
             <X size={24} />
           </button>
@@ -41,6 +46,13 @@ export default function EditAccount({ onToggle }: AccountEditProps) {
               <input id='confirmPw' type='password' className={inputStyle} />
             </div>
           </form>
+          <button
+            type='button'
+            className='block mx-auto mt-20 text-14 font-bold underline text-neutral-500 underline-offset-2'
+            onClick={onToggle}
+          >
+            프로필 정보 수정하기
+          </button>
         </div>
       </Modal.Content>
       <Modal.Actions direction='row'>
@@ -48,7 +60,7 @@ export default function EditAccount({ onToggle }: AccountEditProps) {
           type='submit'
           className='w-full h-45 px-24 text-15 
         text-primary-400 btn-white-pb font-semibold rounded-md'
-          onClick={onToggle}
+          onClick={handleClose}
         >
           취소
         </button>

--- a/src/pages/My/components/EditAccount.tsx
+++ b/src/pages/My/components/EditAccount.tsx
@@ -1,0 +1,65 @@
+import { X } from '@phosphor-icons/react';
+
+import Modal from '@/components/Modal';
+
+import { AccountEditProps } from '../types';
+
+export default function EditAccount({ onToggle }: AccountEditProps) {
+  const fieldStyle = 'flex flex-col focus-within:text-primary-300 transition-2';
+  const inputStyle =
+    'px-0 py-4 rounded-none border-b-1 border-zinc-300 border-neutral-500 focus:border-primary-300 text-neutral-600 transition-2';
+
+  return (
+    <>
+      <Modal.Content>
+        <div className='px-16 pb-16'>
+          <button
+            type='button'
+            className='absolute top-12 right-12'
+            onClick={onToggle}
+          >
+            <X size={24} />
+          </button>
+          <h2 className='text-20 text-center font-semibold pt-12 mb-24'>
+            회원 정보 수정
+          </h2>
+          <form className='flex flex-col gap-20 mb-4 [&_span]:text-14'>
+            <div className={fieldStyle}>
+              <span>이메일</span>
+              <input id='name' type='text' className={inputStyle} />
+            </div>
+            <div className={fieldStyle}>
+              <span>현재 비밀번호</span>
+              <input id='currentPw' type='password' className={inputStyle} />
+            </div>
+            <div className={fieldStyle}>
+              <span>새 비밀번호</span>
+              <input id='newPw' type='password' className={inputStyle} />
+            </div>
+            <div className={fieldStyle}>
+              <span>새 비밀번호 확인</span>
+              <input id='confirmPw' type='password' className={inputStyle} />
+            </div>
+          </form>
+        </div>
+      </Modal.Content>
+      <Modal.Actions direction='row'>
+        <button
+          type='submit'
+          className='w-full h-45 px-24 text-15 
+        text-primary-400 btn-white-pb font-semibold rounded-md'
+          onClick={onToggle}
+        >
+          취소
+        </button>
+        <button
+          type='submit'
+          className='w-full h-45 px-24 bg-primary-300 text-15 
+        text-white font-semibold rounded-md'
+        >
+          변경사항 저장
+        </button>
+      </Modal.Actions>
+    </>
+  );
+}

--- a/src/pages/My/components/EditModal.tsx
+++ b/src/pages/My/components/EditModal.tsx
@@ -1,0 +1,25 @@
+import Modal from '@/components/Modal';
+
+import { ProfileEditModalProps } from '../types';
+
+import EditAccount from './EditAccount';
+import EditProfile from './EditProfile';
+
+export default function EditModal({
+  type = 'profile',
+  isVisible,
+  onClose,
+  onToggle,
+}: ProfileEditModalProps) {
+  const IS_PROFILE_MODAL = type === 'profile';
+
+  return (
+    <Modal isVisible={isVisible} onClose={onClose}>
+      {IS_PROFILE_MODAL ? (
+        <EditProfile onClose={onClose} onToggle={onToggle} />
+      ) : (
+        <EditAccount onToggle={onToggle} />
+      )}
+    </Modal>
+  );
+}

--- a/src/pages/My/components/EditModal.tsx
+++ b/src/pages/My/components/EditModal.tsx
@@ -18,7 +18,7 @@ export default function EditModal({
       {IS_PROFILE_MODAL ? (
         <EditProfile onClose={onClose} onToggle={onToggle} />
       ) : (
-        <EditAccount onToggle={onToggle} />
+        <EditAccount onClose={onClose} onToggle={onToggle} />
       )}
     </Modal>
   );

--- a/src/pages/My/components/EditProfile.tsx
+++ b/src/pages/My/components/EditProfile.tsx
@@ -1,0 +1,77 @@
+import { X } from '@phosphor-icons/react';
+
+import Modal from '@/components/Modal';
+
+import { ProfileEditProps } from '../types';
+
+export default function EditProfile({ onClose, onToggle }: ProfileEditProps) {
+  const fieldStyle = 'flex flex-col focus-within:text-primary-300 transition-2';
+  const inputStyle =
+    'px-0 py-4 rounded-none border-b-1 border-zinc-300 border-neutral-500 focus:border-primary-300 text-neutral-600 transition-2';
+  const labelStyle =
+    'w-148 h-148 border-1 border-zinc-300 rounded-md text-center flex-row-center text-14 text-neutral-600/35 lg:hover:border-primary-400 lg:hover:text-primary-400 transition-2 cursor-pointer';
+
+  return (
+    <>
+      <Modal.Content>
+        <div className='px-16'>
+          <button
+            type='button'
+            className='absolute top-12 right-12'
+            onClick={onClose}
+          >
+            <X size={24} />
+          </button>
+          <h2 className='text-20 text-center font-semibold pt-12 mb-24'>
+            회원 정보 수정
+          </h2>
+          <form className='flex flex-col gap-20 mb-4 [&_span]:text-14'>
+            <div className={fieldStyle}>
+              <span>이름</span>
+              <input id='name' type='text' className={inputStyle} />
+            </div>
+            <div className='flex-col-center gap-8'>
+              <span className='w-full'>프로필 사진 업로드</span>
+              <label htmlFor='file-input' className={labelStyle}>
+                Click to upload an image
+              </label>
+              <input id='file-input' type='file' className='hidden' />
+            </div>
+            <div className={fieldStyle}>
+              <span>소속 학교</span>
+              <input id='password' type='text' className={inputStyle} />
+            </div>
+            <div className={fieldStyle}>
+              <span>학번</span>
+              <input id='password' type='text' className={inputStyle} />
+            </div>
+          </form>
+          <button
+            type='button'
+            className='block mx-auto mt-20 text-14 font-bold underline text-neutral-500 underline-offset-2'
+            onClick={onToggle}
+          >
+            이메일/비밀번호 변경하기(비밀번호 인증 필요)
+          </button>
+        </div>
+      </Modal.Content>
+      <Modal.Actions direction='row'>
+        <button
+          type='submit'
+          className='w-full h-45 px-24 text-15 
+        text-primary-400 btn-white-pb font-semibold rounded-md'
+          onClick={onClose}
+        >
+          취소
+        </button>
+        <button
+          type='submit'
+          className='w-full h-45 px-24 bg-primary-300 text-15 
+        text-white font-semibold rounded-md'
+        >
+          변경사항 저장
+        </button>
+      </Modal.Actions>
+    </>
+  );
+}

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+import useModal from '@/hooks/useModal';
+
+import EditModal from './components/EditModal';
+import { MemberInfo, ProfileEditInfoType } from './types';
+
+export default function MyPage() {
+  const { isVisible, toggleModal } = useModal();
+
+  // 임시
+  const mockData: MemberInfo = {
+    name: 'test',
+    joinDate: '8/23/24',
+    level: '씨앗',
+    school: '양천고',
+    studentId: '12345',
+    email: 'test2@test.com',
+    totalPost: 0,
+    totalComment: 0,
+    profileImg: '',
+  };
+
+  const [infoType, setInfoType] = useState<ProfileEditInfoType>('profile');
+
+  const toggleModalType = () => {
+    setInfoType(infoType === 'profile' ? 'account' : 'profile');
+  };
+
+  const bgColor = !mockData.profileImg && 'bg-primary-300/5';
+
+  return (
+    <div className='w-full max-w-screen-sm m-auto px-24 py-60 flex flex-col gap-20'>
+      <EditModal
+        type={infoType}
+        isVisible={isVisible}
+        onClose={toggleModal}
+        onToggle={toggleModalType}
+      />
+      <div className='flex items-center gap-16'>
+        <div
+          className={`w-58 h-58 rounded-full overflow-hidden border-1 ${bgColor}`}
+        >
+          {mockData.profileImg && (
+            <img src='' alt='profile-img' className='object-cover' />
+          )}
+        </div>
+        <div className='flex-row-center'>
+          <span className='text-primary-400 text-25 font-bold leading-[1.4]'>
+            {mockData.name}
+          </span>
+          <span className='font-semibold'>&nbsp;님, 안녕하세요!</span>
+        </div>
+      </div>
+      <span
+        className='text-neutral-500 underline decoration-1 
+        underline-offset-2 -mt-4 text-14'
+      >
+        계정 생성 일자: {mockData.joinDate}
+      </span>
+      <div className='[&_strong]:font-semibold [&>p]:pb-6'>
+        <p>
+          <strong>회원 등급:</strong> &nbsp;{mockData.level}
+        </p>
+        <p>
+          <strong>소속 학교:</strong> &nbsp;{mockData.school}
+        </p>
+        <p>
+          <strong>학번:</strong> &nbsp;{mockData.studentId}
+        </p>
+        <p>
+          <strong>Email:</strong> &nbsp;{mockData.email}
+        </p>
+        <p>
+          <strong>작성한 게시물 수:</strong> &nbsp;{mockData.totalPost}
+        </p>
+        <p>
+          <strong>작성한 댓글 수: </strong>&nbsp;{mockData.totalComment}
+        </p>
+      </div>
+      <button
+        type='button'
+        className='w-150 m-auto mt-36 px-16 py-8 rounded-full 
+      bg-primary-400 text-white font-semibold'
+        onClick={toggleModal}
+      >
+        정보 수정하기
+      </button>
+    </div>
+  );
+}

--- a/src/pages/My/types/index.ts
+++ b/src/pages/My/types/index.ts
@@ -24,5 +24,3 @@ export type ProfileEditProps = Pick<
   ProfileEditModalProps,
   'onClose' | 'onToggle'
 >;
-
-export type AccountEditProps = Pick<ProfileEditModalProps, 'onToggle'>;

--- a/src/pages/My/types/index.ts
+++ b/src/pages/My/types/index.ts
@@ -1,0 +1,28 @@
+// 임시
+export interface MemberInfo {
+  name: string;
+  joinDate: string;
+  level: string;
+  school: string;
+  studentId: string;
+  email: string;
+  totalPost: number;
+  totalComment: number;
+  profileImg: string;
+}
+
+export type ProfileEditInfoType = 'profile' | 'account';
+
+export interface ProfileEditModalProps {
+  type?: ProfileEditInfoType;
+  isVisible: boolean;
+  onClose: () => void;
+  onToggle: () => void;
+}
+
+export type ProfileEditProps = Pick<
+  ProfileEditModalProps,
+  'onClose' | 'onToggle'
+>;
+
+export type AccountEditProps = Pick<ProfileEditModalProps, 'onToggle'>;

--- a/src/routes/PrivateRoutes.tsx
+++ b/src/routes/PrivateRoutes.tsx
@@ -1,3 +1,22 @@
 import { RouteObject } from 'react-router-dom';
 
-export const privateRoutes: RouteObject[] = [];
+import Layout from '@/components/Layout';
+import PrivateRoute from '@/components/PrivateRoute';
+import MyPage from '@/pages/My';
+
+export const privateRoutes: RouteObject[] = [
+  {
+    path: '/',
+    element: (
+      <PrivateRoute>
+        <Layout />
+      </PrivateRoute>
+    ),
+    children: [
+      {
+        path: '/mypage',
+        element: <MyPage />,
+      },
+    ],
+  },
+];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,18 +46,22 @@ body {
   }
   /* border-white, bg-white, hover 시 배경이 투명해지는 버튼 */
   .btn-white-wb {
-    @apply border-solid border-1 border-white bg-white hover:bg-transparent hover:text-white;
+    @apply border-solid border-1 border-white bg-white lg:hover:bg-transparent lg:hover:text-white;
     transition:
       background-color 0.2s,
       color 0.2s;
   }
   /* border color primary, bg-white, hover 시 배경이 primary/8 */
   .btn-white-pb {
-    @apply border-solid border-1 border-primary-300 bg-white hover:bg-primary-300/8;
+    @apply border-solid border-1 border-primary-300 bg-white lg:hover:bg-primary-300/8;
     transition: background-color 0.2s;
   }
   .input-primary {
     @apply px-6 text-14 h-48 rounded-md border-1 border-[#bdbdbd] focus:border-primary-300 transition duration-200;
+  }
+
+  .transition-2 {
+    @apply transition duration-200
   }
 }
 


### PR DESCRIPTION
## 📝 개요

마이페이지 퍼블리싱

- 반응형 작업하면서 기존 디자인에서 조금 더 깔끔하게 바꿔봤습니다.

https://github.com/user-attachments/assets/18049b13-4d48-47bf-adca-541a2f5f13da


https://github.com/user-attachments/assets/e002c2dc-84f3-4c08-8476-007dfcaed8ee

<img src="https://github.com/user-attachments/assets/0f3cc644-b92e-433d-848d-b3fd06a068b2" width="300px"/>

<br/><br/>

### + 0828 피드백 반영)

https://github.com/user-attachments/assets/46be0798-8cc3-4b73-8f79-32bd7716b2c5

- 이메일/비밀번호 변경 모달에서 취소/닫기 클릭 시 모달을 닫도록 수정
- 이메일/비밀번호 변경 모달에서 프로필 정보 수정 모달로 변경하는 버튼 추가

<br/>

## 🚀 변경사항

custom button hover 스타일 데스크톱에서만 적용되도록 수정했습니다.

## 🔗 관련 이슈

#24

## ➕ 기타

피드백 있으시면 코멘트 남겨주세요~ 모달에서 현재 사용자 정보를 초기 input 값으로 넣는 것도 생각중인데 한 번에 작업하면 너무 많아질 것 같아서 이번 pr에는 반영하지 않았습니다.

<br/>
