### PR TITLE
feat: 회원가입, 로그인 유효성 검사 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
+        "react-hook-form": "^7.53.0",
         "react-router-dom": "^6.26.1",
         "zustand": "^4.5.5"
       },
@@ -6623,6 +6624,21 @@
       },
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+      "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
+    "react-hook-form": "^7.53.0",
     "react-router-dom": "^6.26.1",
     "zustand": "^4.5.5"
   },

--- a/src/components/Header/AuthModal/Login.tsx
+++ b/src/components/Header/AuthModal/Login.tsx
@@ -1,11 +1,13 @@
 import { X } from '@phosphor-icons/react';
-import { Link } from 'react-router-dom';
 
 import Modal from '@/components/Modal';
+import useLoginForm from '@/hooks/auth/useLoginForm';
 import { AuthModalActions } from '@/types/auth';
 
 export default function Login({ onClose, onToggle }: AuthModalActions) {
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
+
+  const { hasErrors, getErrorMessage, register, onSubmit } = useLoginForm();
 
   return (
     <>
@@ -23,7 +25,7 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
             <div className={fieldStyle}>
               <label htmlFor='email'>이메일</label>
               <input
-                id='email'
+                {...register('email', { required: true })}
                 type='text'
                 className='input-primary'
                 placeholder='johndoe@gmail.com'
@@ -32,16 +34,23 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
             <div className={fieldStyle}>
               <label htmlFor='password'>비밀번호</label>
               <input
-                id='password'
+                {...register('password', { required: true })}
                 type='password'
                 className='input-primary'
                 placeholder='********'
+                autoComplete='false'
               />
             </div>
+            {hasErrors && (
+              <span className='text-12 text-center text-red-500'>
+                {getErrorMessage()}를 입력하세요.
+              </span>
+            )}
           </form>
-          <Link className='flex justify-end text-14 text-primary-300' to='/'>
+          {/* 고도화 단계에서 개발 */}
+          {/* <Link className='flex justify-end text-14 text-primary-300' to='/'>
             비밀번호 찾기
-          </Link>
+          </Link> */}
         </div>
       </Modal.Content>
       <Modal.Actions>
@@ -49,6 +58,7 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
           type='submit'
           className='w-full h-45 px-24 bg-primary-300 text-15 
         text-white font-semibold rounded-md'
+          onClick={onSubmit}
         >
           로그인
         </button>

--- a/src/components/Header/AuthModal/Register.tsx
+++ b/src/components/Header/AuthModal/Register.tsx
@@ -1,10 +1,14 @@
 import { X } from '@phosphor-icons/react';
 
 import Modal from '@/components/Modal';
+import useRegisterForm from '@/hooks/auth/useRegisterForm';
 import { AuthModalActions } from '@/types/auth';
 
 export default function Register({ onClose, onToggle }: AuthModalActions) {
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
+
+  const { errors, fieldRules, register, onSubmit } = useRegisterForm();
+
   return (
     <>
       <Modal.Content>
@@ -21,38 +25,58 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
             <div className={fieldStyle}>
               <label htmlFor='name'>이름</label>
               <input
-                id='name'
+                {...register('name', fieldRules.name)}
                 type='text'
                 className='input-primary'
                 placeholder='John Doe'
               />
+              {errors.name && (
+                <span className='text-12 text-red-500'>
+                  {errors.name.message}
+                </span>
+              )}
             </div>
             <div className={fieldStyle}>
               <label htmlFor='email'>이메일</label>
               <input
-                id='email'
+                {...register('email', fieldRules.email)}
                 type='text'
                 className='input-primary'
                 placeholder='johndoe@gmail.com'
               />
+              {errors.email && (
+                <span className='text-12 text-red-500'>
+                  {errors.email.message}
+                </span>
+              )}
             </div>
             <div className={fieldStyle}>
               <label htmlFor='password'>비밀번호</label>
               <input
-                id='password'
+                {...register('password', fieldRules.password)}
                 type='password'
                 className='input-primary'
                 placeholder='********'
               />
+              {errors.password && (
+                <span className='text-12 text-red-500'>
+                  {errors.password.message}
+                </span>
+              )}
             </div>
             <div className={fieldStyle}>
-              <label htmlFor='confrimPw'>비밀번호 확인</label>
+              <label htmlFor='confirmPw'>비밀번호 확인</label>
               <input
-                id='confrimPw'
+                {...register('confirmPw', fieldRules.confirmPw)}
                 type='password'
                 className='input-primary'
                 placeholder='********'
               />
+              {errors.confirmPw && (
+                <span className='text-12 text-red-500'>
+                  {errors.confirmPw.message}
+                </span>
+              )}
             </div>
           </form>
         </div>
@@ -62,6 +86,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
           type='submit'
           className='w-full h-45 px-24 bg-primary-300 text-15 
         text-white font-semibold rounded-md'
+          onClick={onSubmit}
         >
           가입하기
         </button>

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -1,0 +1,39 @@
+import { useForm, FieldValues } from 'react-hook-form';
+
+interface ILoginFormInput {
+  email: string;
+  password: string;
+}
+
+export default function useLoginForm() {
+  const {
+    formState: { errors },
+    register,
+    handleSubmit,
+  } = useForm<ILoginFormInput>({ reValidateMode: 'onSubmit' }); // 폼 제출 시에만 재검증
+
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const getErrorMessage = () => {
+    const emptyFields = [];
+    if (errors.email) emptyFields.push('이메일');
+    if (errors.password) emptyFields.push('비밀번호');
+    return emptyFields.join(', ');
+  };
+
+  const login = (data: FieldValues) => {
+    alert(JSON.stringify(data)); // 확인용, 추후 제거
+    // login
+  };
+
+  const onSubmit = () => {
+    handleSubmit(login)();
+  };
+
+  return {
+    hasErrors,
+    getErrorMessage,
+    register,
+    onSubmit,
+  };
+}

--- a/src/hooks/auth/useRegisterForm.ts
+++ b/src/hooks/auth/useRegisterForm.ts
@@ -1,0 +1,64 @@
+import { useForm, FieldValues, RegisterOptions } from 'react-hook-form';
+
+interface IRegisterFormInput {
+  name: string;
+  email: string;
+  password: string;
+  confirmPw: string;
+}
+
+type FieldRules = {
+  [K in keyof IRegisterFormInput]: RegisterOptions<IRegisterFormInput, K>;
+};
+
+export default function useRegisterForm() {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<IRegisterFormInput>({ mode: 'onBlur' }); // blur 시 유효성 검사, 재검증 onChange(default)
+
+  const fieldRules: FieldRules = {
+    name: { required: '이름을 입력하세요.' },
+    email: {
+      required: '이메일을 입력하세요.',
+      pattern: {
+        value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+        message: '올바르지 않은 이메일 형식입니다.',
+      },
+    },
+    password: {
+      required: '비밀번호를 입력하세요.',
+      minLength: {
+        value: 6,
+        message: '비밀번호는 최소 6자 이상이어야 합니다.',
+      },
+      maxLength: {
+        value: 20,
+        message: '비밀번호는 최대 20자까지 입력할 수 있습니다.',
+      },
+    },
+    confirmPw: {
+      required: '비밀번호 확인을 입력하세요.',
+      validate: {
+        match: (value, { password }) =>
+          value === password || '비밀번호가 일치하지 않습니다.',
+      },
+    },
+  };
+  const signUp = (data: FieldValues) => {
+    alert(JSON.stringify(data)); // 확인용, 추후 제거
+    // signup
+  };
+
+  const onSubmit = () => {
+    handleSubmit(signUp)();
+  };
+
+  return {
+    errors,
+    fieldRules,
+    register,
+    onSubmit,
+  };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,7 +61,7 @@ body {
   }
 
   .transition-2 {
-    @apply transition duration-200
+    @apply transition duration-200;
   }
 }
 


### PR DESCRIPTION
## 📝 개요

회원가입, 로그인 유효성 검사 추가

- 회원가입


https://github.com/user-attachments/assets/d28ad9f5-6bd2-4e03-87dd-80594f98f7d0


input blur 시 검증, submit 실패할 경우 onChange 재검증

<br/>

- 로그인

https://github.com/user-attachments/assets/05a177f2-a08d-407f-8eec-8701973479c4

로그인 버튼 클릭 시 검증/재검증

## 🚀 변경사항

react-hook-form 의존성 추가

## 🔗 관련 이슈

#44 


## ➕ 기타

노션 개발 정보 공유에 react-hook-form 관련 포스팅 링크 넣어뒀어요. 한번 가볍게 보시는 것도 좋을 것 같습니다!

<br/>

