### PR TITLE
feat: 회원가입 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -61,7 +61,6 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'consistent-return': 'off',
     'react-refresh/only-export-components': 'off',
-    'class-methods-use-this': 'off',
     camelcase: 'off',
     'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -61,6 +61,7 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'consistent-return': 'off',
     'react-refresh/only-export-components': 'off',
+    'class-methods-use-this': 'off',
     camelcase: 'off',
     'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },

--- a/src/components/Header/AuthModal/Login.tsx
+++ b/src/components/Header/AuthModal/Login.tsx
@@ -26,6 +26,7 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='email'>이메일</label>
               <input
                 {...register('email', { required: true })}
+                id='email'
                 type='text'
                 className='input-primary'
                 placeholder='johndoe@gmail.com'
@@ -35,6 +36,7 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='password'>비밀번호</label>
               <input
                 {...register('password', { required: true })}
+                id='password'
                 type='password'
                 className='input-primary'
                 placeholder='********'

--- a/src/components/Header/AuthModal/Register.tsx
+++ b/src/components/Header/AuthModal/Register.tsx
@@ -59,6 +59,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
                 type='password'
                 className='input-primary'
                 placeholder='********'
+                autoComplete='false'
               />
               {errors.password && (
                 <span className='text-12 text-red-500'>
@@ -73,6 +74,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
                 type='password'
                 className='input-primary'
                 placeholder='********'
+                autoComplete='false'
               />
               {errors.confirmPw && (
                 <span className='text-12 text-red-500'>

--- a/src/components/Header/AuthModal/Register.tsx
+++ b/src/components/Header/AuthModal/Register.tsx
@@ -28,6 +28,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='name'>이름</label>
               <input
                 {...register('name', fieldRules.name)}
+                id='name'
                 type='text'
                 className='input-primary'
                 placeholder='John Doe'
@@ -42,6 +43,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='email'>이메일</label>
               <input
                 {...register('email', fieldRules.email)}
+                id='email'
                 type='text'
                 className='input-primary'
                 placeholder='johndoe@gmail.com'
@@ -56,6 +58,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='password'>비밀번호</label>
               <input
                 {...register('password', fieldRules.password)}
+                id='password'
                 type='password'
                 className='input-primary'
                 placeholder='********'
@@ -71,6 +74,7 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
               <label htmlFor='confirmPw'>비밀번호 확인</label>
               <input
                 {...register('confirmPw', fieldRules.confirmPw)}
+                id='confirmPw'
                 type='password'
                 className='input-primary'
                 placeholder='********'

--- a/src/components/Header/AuthModal/Register.tsx
+++ b/src/components/Header/AuthModal/Register.tsx
@@ -7,7 +7,9 @@ import { AuthModalActions } from '@/types/auth';
 export default function Register({ onClose, onToggle }: AuthModalActions) {
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
 
-  const { errors, fieldRules, register, onSubmit } = useRegisterForm();
+  const { errors, fieldRules, register, onSubmit } = useRegisterForm({
+    onSuccess: onToggle,
+  });
 
   return (
     <>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = `${import.meta.env.VITE_API_ROOT as string}/api/v1`;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = `${import.meta.env.VITE_API_ROOT as string}/api/v1`;
+export const BASE_URL = import.meta.env.VITE_API_ROOT as string;

--- a/src/hooks/auth/useRegisterForm.ts
+++ b/src/hooks/auth/useRegisterForm.ts
@@ -1,7 +1,8 @@
 import { isAxiosError } from 'axios';
-import { useForm, FieldValues, RegisterOptions } from 'react-hook-form';
+import { useForm, FieldValues } from 'react-hook-form';
 
 import auth from '@/services/auth';
+import { FieldRules } from '@/types';
 import { UseAuthFormProps } from '@/types/auth';
 
 interface IRegisterFormInput {
@@ -11,10 +12,6 @@ interface IRegisterFormInput {
   confirmPw: string;
 }
 
-type FieldRules = {
-  [K in keyof IRegisterFormInput]: RegisterOptions<IRegisterFormInput, K>;
-};
-
 export default function useRegisterForm({ onSuccess }: UseAuthFormProps) {
   const {
     register,
@@ -22,7 +19,7 @@ export default function useRegisterForm({ onSuccess }: UseAuthFormProps) {
     handleSubmit,
   } = useForm<IRegisterFormInput>({ mode: 'onBlur' }); // blur 시 유효성 검사, 재검증 onChange(default)
 
-  const fieldRules: FieldRules = {
+  const fieldRules: FieldRules<IRegisterFormInput> = {
     name: { required: '이름을 입력하세요.' },
     email: {
       required: '이메일을 입력하세요.',

--- a/src/hooks/auth/useRegisterForm.ts
+++ b/src/hooks/auth/useRegisterForm.ts
@@ -1,4 +1,8 @@
+import { isAxiosError } from 'axios';
 import { useForm, FieldValues, RegisterOptions } from 'react-hook-form';
+
+import auth from '@/services/auth';
+import { UseAuthFormProps } from '@/types/auth';
 
 interface IRegisterFormInput {
   name: string;
@@ -11,7 +15,7 @@ type FieldRules = {
   [K in keyof IRegisterFormInput]: RegisterOptions<IRegisterFormInput, K>;
 };
 
-export default function useRegisterForm() {
+export default function useRegisterForm({ onSuccess }: UseAuthFormProps) {
   const {
     register,
     formState: { errors },
@@ -46,12 +50,26 @@ export default function useRegisterForm() {
       },
     },
   };
-  const signUp = (data: FieldValues) => {
-    alert(JSON.stringify(data)); // 확인용, 추후 제거
-    // signup
+
+  const signUp = async (data: FieldValues) => {
+    const { name, email, password } = data;
+    try {
+      await auth.signUp(name, email, password);
+      alert('회원가입이 완료되었습니다.');
+      onSuccess();
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status) {
+        const { status } = error.response;
+        const {
+          result: { message },
+        } = error.response.data;
+        if (status === 409) alert(message);
+      }
+      console.log(error);
+    }
   };
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     handleSubmit(signUp)();
   };
 

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+
+import { BASE_URL } from '@/config';
+
+const instance = axios.create({
+  baseURL: BASE_URL,
+  timeout: 3 * 1000,
+  // withCredentials: true,
+  // 현재 be에서 Access-Control-Allow-Origin 값을 *(와일드카드)로 설정해두었기 때문에
+  // withCredentials 사용이 불가능합니다. (오류 발생)
+  // 추후 be 세팅 변경 후 변경 예정
+});
+
+// Request interceptor
+instance.interceptors.request.use(config => {
+  return config;
+});
+
+// Response interceptor
+instance.interceptors.response.use(
+  response => {
+    return response.data.result;
+  },
+  error => {
+    return Promise.reject(error);
+  },
+);
+
+export function get<T>(...args: Parameters<typeof instance.get>) {
+  return instance.get<T, T>(...args);
+}
+
+export function post<T>(...args: Parameters<typeof instance.post>) {
+  return instance.post<T, T>(...args);
+}
+
+export function put<T>(...args: Parameters<typeof instance.put>) {
+  return instance.put<T, T>(...args);
+}
+
+export function patch<T>(...args: Parameters<typeof instance.patch>) {
+  return instance.patch<T, T>(...args);
+}
+
+export function del<T>(...args: Parameters<typeof instance.delete>) {
+  return instance.delete<T, T>(...args);
+}
+
+export default {
+  get,
+  post,
+  put,
+  patch,
+  delete: del,
+};

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,13 @@
+import { post } from '@/libs/api';
+
+class AuthApi {
+  async signUp(name: string, email: string, password: string) {
+    return post('/auth/signup', {
+      name,
+      email,
+      password,
+    });
+  }
+}
+
+export default new AuthApi();

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,7 @@
 import { post } from '@/libs/api';
 
 class AuthApi {
-  async signUp(name: string, email: string, password: string) {
+  static async signUp(name: string, email: string, password: string) {
     return post('/auth/signup', {
       name,
       email,
@@ -10,4 +10,4 @@ class AuthApi {
   }
 }
 
-export default new AuthApi();
+export default AuthApi;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -8,3 +8,7 @@ export interface AuthModalProps {
 }
 
 export type AuthModalActions = Pick<AuthModalProps, 'onClose' | 'onToggle'>;
+
+export interface UseAuthFormProps {
+  onSuccess: () => void;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { FieldValues, Path, RegisterOptions } from 'react-hook-form';
 
 /**
  * prop에 `children`  반드시 포함하도록 강제하는 역할을 합니다.
@@ -7,4 +8,13 @@ import { ReactNode } from 'react';
  * */
 export type StrictPropsWithChildren<P = unknown> = P & {
   children: ReactNode;
+};
+
+/**
+ * form에 적용할 rule 타입으로 사용합니다.
+ *
+ * @example FieldRules<IRegisterFormInput>
+ * */
+export type FieldRules<T extends FieldValues> = {
+  [K in Path<T>]: RegisterOptions<T, K>;
 };


### PR DESCRIPTION
## 📝 개요

- 회원가입 (성공)

https://github.com/user-attachments/assets/fca32135-f42b-47ea-9f1a-bf1338645868

회원가입 완료 후 로그인 모달로 전환

<br/>

- 회원가입 (이메일 중복)

https://github.com/user-attachments/assets/7ebf0cca-9c15-42f6-a674-c9edb6b47f0a


## 🚀 변경사항

- axios instance가 세팅되었습니다. 아주 기본적인 부분만 설정되어 있기 때문에 의견이 있으시면 코멘트 주세요.
- response interceptor에서 요청 성공 시 resultsCode는 필요하지 않다고 생각하여 바로 데이터(result)를 return 합니다.
아래와 같이 사용하실 수 있습니다.

```typescript
import { post } from '@/libs/api';

interface LoginResponse {
  accessToken: string;
}

// 응답 타입을 미리 한번 확인해 보시고 타입을 추가하시면 좋습니다.
const { accessToken } = await post<LoginResponse>('/auth/login', {
  email,
  password,
});

console.log(accessToken); // Bear eyJhbGciOiJ...
```

- axios interceptor에서 에러 핸들링 관련으로 의견 있으시면 코멘트 주세요!

## 🔗 관련 이슈

#45

## ➕ 기타

.env.development에 추가해 주세요! 백엔드 도메인 설정 전까지 url이 종종 바뀔 수 있으니 유의해 주세요.
```bash
VITE_API_ROOT=URL/api/v1 (URL 디스코드 참고)
```

<br/>
