### PR TITLE
등업 시키기 기능 퍼블리싱

### DIFF
--- a/src/pages/Community/LevelUp.tsx
+++ b/src/pages/Community/LevelUp.tsx
@@ -12,6 +12,8 @@ function LevelUp() {
   const { isVisible, toggleModal } = useModal();
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [filteredPosts, setFilteredPosts] = useState<Post[]>(initialPosts);
+  const [isLevelingUp, setIsLevelingUp] = useState<boolean>(false); // 등업하기 상태
+  const [userRole, setUserRole] = useState<string>(''); 
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -21,6 +23,19 @@ function LevelUp() {
       setFilteredPosts(filtered);
     }
   };
+
+  const handleLevelUpClick = () => {
+    setIsLevelingUp(true); // 등업하기 버튼을 누르면 등업하기 상태로 전환
+  };
+
+  const handleCancelOrComplete = () => {
+    window.location.reload(); // 취소 혹은 완료 시 페이지 새로고침
+  };
+
+  const handleRoleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setUserRole(e.target.value); // 셀렉트 박스에서 역할 선택 시 상태 변경
+  };
+
 
   return (
     <div className='flex flex-col text-center mt-20'>
@@ -50,10 +65,54 @@ function LevelUp() {
           글쓰기
         </button>
       </div>
+      {/* isLevelingUp이 true면 셀렉트 박스로 관리자 학생을 선택 */}
+      {isLevelingUp ? (
+        <div className='flex justify-start mb-10 ml-20'>
+          <select
+            value={userRole}
+            onChange={handleRoleChange}
+            className='border-2 rounded-lg p-2'
+          >
+            <option value='' disabled>
+              등급 변경
+            </option>
+            <option value='관리자'>관리자</option>
+            <option value='학생'>학생</option>
+          </select>
+        </div>
+      ) : null}
+      
       {isVisible && (
         <WritePostModal isVisible={isVisible} onClose={toggleModal} />
       )}
-      <PostTable posts={filteredPosts} />
+      <PostTable posts={filteredPosts} isLevelingUp={isLevelingUp} />
+
+      <div className='mt-10 flex justify-end pr-30'>
+        {/* 차후 관리자 계정인지 판별하는 로직 보충 */}
+        {!isLevelingUp ? (
+          <button
+            onClick={handleLevelUpClick}
+            className='text-sm py-2 px-10 md:py-8 md:px-30 rounded-3xl bg-primary-400 text-white hover:opacity-80'
+          >
+            등업하기
+          </button>
+        ) : (
+          <div className='flex flex-row space-x-4'>
+            <button
+              onClick={handleCancelOrComplete}
+              className='text-sm py-2 px-10 md:py-8 md:px-30 rounded-3xl bg-gray-400 text-white hover:opacity-80'
+            >
+              취소
+            </button>
+            <button
+              onClick={handleCancelOrComplete}
+              className='text-sm py-2 px-10 md:py-8 md:px-30 rounded-3xl bg-primary-400 text-white hover:opacity-80'
+            >
+              완료
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/Community/LevelUp.tsx
+++ b/src/pages/Community/LevelUp.tsx
@@ -13,7 +13,7 @@ function LevelUp() {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [filteredPosts, setFilteredPosts] = useState<Post[]>(initialPosts);
   const [isLevelingUp, setIsLevelingUp] = useState<boolean>(false); // 등업하기 상태
-  const [userRole, setUserRole] = useState<string>(''); 
+  const [userRole, setUserRole] = useState<string>('');
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -35,7 +35,6 @@ function LevelUp() {
   const handleRoleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setUserRole(e.target.value); // 셀렉트 박스에서 역할 선택 시 상태 변경
   };
-
 
   return (
     <div className='flex flex-col text-center mt-20'>
@@ -81,7 +80,7 @@ function LevelUp() {
           </select>
         </div>
       ) : null}
-      
+
       {isVisible && (
         <WritePostModal isVisible={isVisible} onClose={toggleModal} />
       )}

--- a/src/pages/Community/components/Hero.tsx
+++ b/src/pages/Community/components/Hero.tsx
@@ -15,7 +15,7 @@ function Hero() {
         </p>
         <h1
           className={
-            'font-bold text-primary-300 text-center text-40 md:text-50 lg:text-80 '
+            'font-bold text-primary-300 text-center text-40 md:text-50 lg:text-80 break-keep'
           }
         >
           전국 학생들이 하나로 모이는 공간!

--- a/src/pages/Community/components/PostData.tsx
+++ b/src/pages/Community/components/PostData.tsx
@@ -3,12 +3,17 @@ import { Link } from 'react-router-dom';
 
 import { PostTableProps, PostDetailsProps } from '../types/PostData';
 
-export function PostTable({ posts }: PostTableProps) {
+export function PostTable({ posts, isLevelingUp }: PostTableProps) {
   return (
     <div className='overflow-x-auto'>
       <table className='w-full text-sm sm:text-base'>
         <thead>
           <tr className='border-t-2 border-t-gray-400 border-b-2 border-b-primary-400'>
+            {isLevelingUp && (
+                <th className='px-20 py-10'>
+                  등업
+                </th>
+              )}
             <th className='px-20 py-10'>No.</th>
             <th className='px-20 py-10'>제목</th>
             <th className='hidden md:table-cell px-20 py-10'>글쓴이</th>
@@ -24,6 +29,11 @@ export function PostTable({ posts }: PostTableProps) {
               key={post.id}
               className='space-x-5 border-b border-b-gray-400 cursor-pointer'
             >
+              {isLevelingUp && (
+                <td className='px-20 py-10'>
+                  <input type="checkbox" />
+                </td>
+              )}
               <td className='px-20 py-10'>{post.id}</td>
               <td className='px-20 py-10'>
                 <Link to={`/community_project/${post.id}`}>

--- a/src/pages/Community/components/PostData.tsx
+++ b/src/pages/Community/components/PostData.tsx
@@ -9,11 +9,7 @@ export function PostTable({ posts, isLevelingUp }: PostTableProps) {
       <table className='w-full text-sm sm:text-base'>
         <thead>
           <tr className='border-t-2 border-t-gray-400 border-b-2 border-b-primary-400'>
-            {isLevelingUp && (
-                <th className='px-20 py-10'>
-                  등업
-                </th>
-              )}
+            {isLevelingUp && <th className='px-20 py-10'>등업</th>}
             <th className='px-20 py-10'>No.</th>
             <th className='px-20 py-10'>제목</th>
             <th className='hidden md:table-cell px-20 py-10'>글쓴이</th>
@@ -31,7 +27,7 @@ export function PostTable({ posts, isLevelingUp }: PostTableProps) {
             >
               {isLevelingUp && (
                 <td className='px-20 py-10'>
-                  <input type="checkbox" />
+                  <input type='checkbox' />
                 </td>
               )}
               <td className='px-20 py-10'>{post.id}</td>

--- a/src/pages/Community/types/PostData.ts
+++ b/src/pages/Community/types/PostData.ts
@@ -11,6 +11,7 @@ export interface Post {
 
 export interface PostTableProps {
   posts: Post[];
+  isLevelingUp: boolean;
   // onSelectPost: (post: Post) => void;
 }
 

--- a/src/pages/Community/types/PostData.ts
+++ b/src/pages/Community/types/PostData.ts
@@ -11,7 +11,7 @@ export interface Post {
 
 export interface PostTableProps {
   posts: Post[];
-  isLevelingUp: boolean;
+  isLevelingUp?: boolean;
   // onSelectPost: (post: Post) => void;
 }
 


### PR DESCRIPTION
## 📝 개요

등업게시판에서 등업시키기 기능 퍼블리싱 진행하였습니다.

## 🚀 변경사항

1. 관리자 계정일 시 페이지 하단에 등업하기 버튼 확인 가능
2. 등업하기 버튼 클릭시 
- 취소, 완료로 버튼 변경 
- 체크박스
- 상단에 등급 변경 셀렉트 박스 
3. 체크박스로 사용자 선택 후 등급 선택한 뒤 완료 버튼 누르면 등업 완료
4. 미희님이 피드백 주신 break-keep 반영하였습니다.


https://github.com/user-attachments/assets/dc5c520b-50c2-46c2-8330-4be679175da2




## 🔗 관련 이슈

#58 

## ➕ 기타
1. 관리자 계정인지 판별하는 로직 보충


+) 요즘 제가 pr이 뜸해졌는데, 주로 남은 작업이 백엔드 연동이라 이 부분이 아직 제대로 테스트 하기 어려운 부분들이 있어서 추후 오류가 해결되면 pr 업로드가 가능할 것 같습니다ㅠㅜ 확실하지 않은 코드를 합치는 건 안 될 것 같아서요..! 그 외에 가능한 것들부터 최대한 작업하고 있겠습니다.