### PR TITLE
feat: 인증 관리 2차

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@types/node": "^22.5.4",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/uuid": "^10.0.0",
@@ -1980,6 +1981,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -7923,6 +7933,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "compressorjs": "^1.2.1",
         "dompurify": "^3.1.6",
         "framer-motion": "^11.3.29",
+        "memoize": "^10.0.0",
         "quill": "^2.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5834,6 +5835,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/memoize": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.0.0.tgz",
+      "integrity": "sha512-H6cBLgsi6vMWOcCpvVCdFFnl3kerEXbrYh9q+lY6VXvQSmM6CkmV08VOwT+WE2tzIEqRPFfAq3fm4v/UIW6mSA==",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5903,7 +5918,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@types/node": "^22.5.4",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compressorjs": "^1.2.1",
     "dompurify": "^3.1.6",
     "framer-motion": "^11.3.29",
+    "memoize": "^10.0.0",
     "quill": "^2.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -21,7 +21,7 @@ function MemberButtons({ name }: { name: string }) {
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-fit h-36 flex-row-center text-14 font-semibold text-primary-400'
+            'w-fit px-16 h-36 flex-row-center text-14 font-semibold text-primary-400'
           }
         >
           {name}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = import.meta.env.VITE_API_ROOT as string;
+export const BASE_URL = '/api/v1';

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -5,9 +5,8 @@ import userApi from '@/services/user';
 import useBoundStore from '@/stores';
 
 export default function useAuth() {
-  const { isAutoLogin, user, setUser } = useBoundStore(state => ({
+  const { isAutoLogin, setUser } = useBoundStore(state => ({
     isAutoLogin: state.isAutoLogin,
-    user: state.user,
     setUser: state.setUser,
   }));
 
@@ -19,10 +18,9 @@ export default function useAuth() {
   });
 
   useEffect(() => {
-    if (data && data !== user && isAutoLogin) {
-      // 새로운 사용자 데이터가 기존 데이터와 다를 때만 업데이트
+    if (data && isAutoLogin) {
       setUser(data);
       // console.log('user data fetched'); // 확인용, 추후 제거
     }
-  }, [data, setUser, user, isAutoLogin]);
+  }, [data, setUser, isAutoLogin]);
 }

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useForm, FieldValues } from 'react-hook-form';
 
@@ -14,7 +14,6 @@ interface ILoginFormInput {
 
 export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
   const setIsAutoLogin = useBoundStore(state => state.setIsAutoLogin);
-  const queryClient = useQueryClient();
 
   const {
     formState: { errors },
@@ -47,7 +46,6 @@ export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
     mutationFn: ({ email, password }: ILoginFormInput) =>
       auth.login(email, password),
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ['user'] });
       setIsAutoLogin();
       onSuccess();
     },

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useForm, FieldValues } from 'react-hook-form';
 
@@ -14,6 +14,7 @@ interface ILoginFormInput {
 
 export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
   const setIsAutoLogin = useBoundStore(state => state.setIsAutoLogin);
+  const queryClient = useQueryClient();
 
   const {
     formState: { errors },
@@ -46,6 +47,7 @@ export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
     mutationFn: ({ email, password }: ILoginFormInput) =>
       auth.login(email, password),
     onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ['user'] });
       setIsAutoLogin();
       onSuccess();
     },

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,9 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 
 export default function useLogout() {
+  const queryClient = useQueryClient();
+
   const { resetAuthState, resetUser } = useBoundStore(state => ({
     resetAuthState: state.resetAuthState,
     resetUser: state.resetUser,
@@ -17,6 +20,7 @@ export default function useLogout() {
       resetAuthState();
       resetUser();
       navigate('/');
+      queryClient.removeQueries({ queryKey: ['user'] });
     } catch (error) {
       console.log('error with logout: ', error);
     }

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 
 export default function useLogout() {
@@ -10,12 +11,15 @@ export default function useLogout() {
 
   const navigate = useNavigate();
 
-  const handleLogout = () => {
-    // TODO 쿠키 삭제 요청
-    // TODO 성공 시에만 client 토큰 및 사용자 정보 초기화 하도록 수정
-    resetAuthState();
-    resetUser();
-    navigate('/');
+  const handleLogout = async () => {
+    try {
+      await auth.logout();
+      resetAuthState();
+      resetUser();
+      navigate('/');
+    } catch (error) {
+      console.log('error with logout: ', error);
+    }
   };
 
   return { handleLogout };

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -5,7 +5,7 @@ import { BASE_URL } from '@/config';
 import useBoundStore from '@/stores';
 
 // access token 재발급
-const reIssueAccessToken = memoize(
+const reissueAccessToken = memoize(
   async (): Promise<string> => {
     try {
       const { data } = await axios.get('/auth/reissue', {
@@ -71,7 +71,7 @@ instance.interceptors.response.use(
       // isAutoLogin: 로그인 하지 않은 사용자의 토큰 재발급 요청을 방지합니다.
       const originalRequest = error.config;
 
-      const newToken = await reIssueAccessToken();
+      const newToken = await reissueAccessToken();
       useBoundStore.setState({ accessToken: newToken });
       originalRequest.headers.authorization = `Bearer ${newToken}`;
 

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -4,6 +4,8 @@ import memoize from 'memoize';
 import { BASE_URL } from '@/config';
 import useBoundStore from '@/stores';
 
+import { queryClient } from './react-query';
+
 // access token 재발급
 const reissueAccessToken = memoize(
   async (): Promise<string> => {
@@ -22,6 +24,7 @@ const reissueAccessToken = memoize(
       await axios.delete('/auth/logout', {
         baseURL: BASE_URL,
       });
+      queryClient.removeQueries({ queryKey: ['user'] });
       return Promise.reject(refreshError);
     }
   },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,4 @@
-import { post } from '@/libs/api';
+import { del, post } from '@/libs/api';
 import { TokenResponse } from '@/types/auth';
 
 class AuthApi {
@@ -15,6 +15,10 @@ class AuthApi {
       email,
       password,
     });
+  }
+
+  static async logout() {
+    return del('/auth/logout');
   }
 }
 

--- a/src/stores/authSlice.ts
+++ b/src/stores/authSlice.ts
@@ -1,5 +1,4 @@
 import { StateCreator } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 type State = {
   accessToken: string | null;
@@ -19,14 +18,9 @@ const initialState: State = {
   isAutoLogin: false,
 };
 
-const createAuthSlice: StateCreator<AuthSlice> = set => ({
+export const createAuthSlice: StateCreator<AuthSlice> = set => ({
   ...initialState,
   fetchAccessToken: accessToken => set({ accessToken }),
   resetAuthState: () => set(initialState),
   setIsAutoLogin: () => set({ isAutoLogin: true }),
-});
-
-export const createPersistedAuthSlice = persist(createAuthSlice, {
-  name: 'abcdedu',
-  partialize: state => ({ isAutoLogin: state.isAutoLogin }), // isAutoLogin만 localStorage에 저장
 });

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,13 +1,25 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-import { AuthSlice, createPersistedAuthSlice } from './authSlice';
+import { AuthSlice, createAuthSlice } from './authSlice';
 import { UserSlice, createUserSlice } from './userSlice';
 
 type StoreState = AuthSlice & UserSlice;
 
-const useBoundStore = create<StoreState>()((...a) => ({
-  ...createPersistedAuthSlice(...a),
-  ...createUserSlice(...a),
-}));
+const useBoundStore = create<StoreState>()(
+  persist(
+    (set, get, api) => ({
+      ...createAuthSlice(set, get, api),
+      ...createUserSlice(set, get, api),
+    }),
+    {
+      name: 'abcdedu',
+      partialize: state => ({
+        isAutoLogin: state.isAutoLogin,
+        user: state.user,
+      }),
+    },
+  ),
+);
 
 export default useBoundStore;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,25 @@
 import react from '@vitejs/plugin-react-swc';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), svgr()],
-  server: {
-    host: '0.0.0.0',
-    port: 3000,
-  },
-  resolve: {
-    alias: {
-      '@': '/src',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  return {
+    plugins: [react(), svgr()],
+    server: {
+      host: '0.0.0.0',
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_ROOT,
+          changeOrigin: true,
+        },
+      },
     },
-  },
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+  };
 });


### PR DESCRIPTION
## 📝 개요

쿠키 세팅 및 로그인 유지(토큰 재발급 + 이전 요청 재요청), 로그아웃이 구현되었습니다.
이제 새로 고침 시에도 로그인 상태가 유지됩니다.

1. 기존에는 새로 고침 시 401 응답 시점부터 토큰 재발급이 완료되는 짧은 시간 동안 사용자 정보가 null이 되어 잠시 로그아웃 처리 되는 문제가 있었습니다. 이를 해결하기 위해 user(name, role) 정보도 persist를 적용하게 되었습니다.

https://github.com/user-attachments/assets/3255e926-444a-4ae9-847f-e3e9bd5ea6ba


<br/>


2. 페이지 내에서 여러 api 요청이 있을 경우 토큰 재발급 요청도 api 요청 개수만큼 발생하는 문제가 있었습니다. 이와 같은 중복 요청을 해결하기 위해 토큰 재발급 요청에 memoization을 적용했습니다.

- before

![reissue1](https://github.com/user-attachments/assets/a13121c0-da2f-4713-84b2-68192b401f3e)

- after

![image](https://github.com/user-attachments/assets/df6dc084-e57f-4ed2-bc44-6853bee27f68)

3. 관리자 등급 권한 오류 403 예외 처리 적용


## 🚀 변경사항

- memoize 의존성 추가
- vite.config.js에서 env 사용을 위한 @types/node 의존성 추가

- 도메인 이슈로 새로고침 시 쿠키가 삭제되는 문제가 있었습니다. 이를 해결하기 위해 **proxy 설정**이 추가되었습니다. proxy가 추가되면서 env 파일의 API_ROOT 값이 변경되었습니다. 디스코드 확인해주세요!


## 🔗 관련 이슈

#50

## ➕ 기타

interceptor에서 토큰 재발급 함수를 다른 곳에 분리할지 지금처럼 같은 파일에 둘지 고민이네요. 다른 곳에 분리한다면 어디에 할지도... 의견 남겨주시면 감사하겠습니다!

<br/>
