### PR TITLE
feat: 관리자 문의 조회 구현

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -53,6 +53,9 @@ function AdminLayout() {
           <Link to={'/admin/theory'} className={LinkStyle}>
             이론 관리
           </Link>
+          <Link to={'/admin/contact'} className={LinkStyle}>
+            문의 관리
+          </Link>
         </div>
       </aside>
       <section

--- a/src/pages/Admin/Contact/components/ContactDetailLoading.tsx
+++ b/src/pages/Admin/Contact/components/ContactDetailLoading.tsx
@@ -1,0 +1,15 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function ContactDetailLoading() {
+  return (
+    <div>
+      <Skeleton w={160} h={36} style={{ marginBottom: '20px' }} />
+      <div className='flex flex-col gap-8 pb-24 min-h-[300px]'>
+        <Skeleton w={270} h={100} />
+        <hr className='my-12'></hr>
+        <Skeleton w={200} h={27} />
+        <Skeleton w={100} wUnit='%' h={100} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Admin/Contact/components/ContactDetailModal.tsx
+++ b/src/pages/Admin/Contact/components/ContactDetailModal.tsx
@@ -1,0 +1,70 @@
+import { X } from '@phosphor-icons/react';
+
+import Modal from '@/components/Modal';
+import { ContactType } from '@/types/contact';
+
+import { contactTypeLabel } from '../../constants';
+import useGetContact from '../hooks/useGetContact';
+
+import ContactDetailLoading from './ContactDetailLoading';
+
+interface ContactDetailModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  id: number | null;
+}
+
+export default function ContactDetailModal({
+  isVisible,
+  onClose,
+  id,
+}: ContactDetailModalProps) {
+  const { data, isLoading, isError } = useGetContact(id);
+  if (!id) return null;
+
+  if (isError || (!isLoading && !data)) {
+    alert('문의 내용을 불러오는 중 오류가 발생했습니다.');
+    onClose();
+  }
+
+  const textStyle = 'flex gap-16 [&_span]:text-neutral-500';
+  return (
+    <Modal size='lg' isVisible={isVisible} onClose={onClose}>
+      <Modal.Content>
+        <button
+          type='button'
+          className='absolute top-12 right-12'
+          onClick={onClose}
+        >
+          <X size={24} />
+        </button>
+        {isLoading ? (
+          <ContactDetailLoading />
+        ) : (
+          <>
+            <h2 className='text-24 font-semibold mb-20'>
+              {contactTypeLabel[data?.type as ContactType]}
+            </h2>
+            <div className='flex flex-col gap-4 pb-24 min-h-[300px]'>
+              <p className={textStyle}>
+                <span>작성자</span> {data?.userName}
+              </p>
+              <p className={textStyle}>
+                <span>연락처</span> {data?.phoneNumber}
+              </p>
+              <p className={textStyle}>
+                <span>이메일</span> {data?.email}
+              </p>
+              <p className={textStyle}>
+                <span>작성일</span> {data?.createdAt}
+              </p>
+              <hr className='my-12'></hr>
+              <p className='text-18 font-semibold mb-8'>{data?.title}</p>
+              <p>{data?.content}</p>
+            </div>
+          </>
+        )}
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/src/pages/Admin/Contact/hooks/useGetContact.ts
+++ b/src/pages/Admin/Contact/hooks/useGetContact.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import contactApi from '@/services/contact';
+
+export default function useGetContact(contactId: number | null) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['contact', contactId],
+    queryFn: () => contactApi.getContactDetail(Number(contactId)),
+    enabled: Boolean(contactId),
+  });
+
+  return { data, isLoading, isError };
+}

--- a/src/pages/Admin/Contact/hooks/useGetContactList.ts
+++ b/src/pages/Admin/Contact/hooks/useGetContactList.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import contactApi from '@/services/contact';
+
+export default function useGetContactList() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['contact'],
+    queryFn: () => contactApi.getContactList(),
+  });
+
+  const list = data || [];
+
+  return { list, isLoading, isError };
+}

--- a/src/pages/Admin/Contact/index.tsx
+++ b/src/pages/Admin/Contact/index.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+import useModal from '@/hooks/useModal';
+import { ContactType } from '@/types/contact';
+
+import { contactTypeLabel, tableColumnMap, tableColumns } from '../constants';
+
+import ContactDetailModal from './components/ContactDetailModal';
+import useGetContactList from './hooks/useGetContactList';
+
+export default function ContactList() {
+  const { list, isLoading, isError } = useGetContactList();
+  const { isVisible, toggleModal } = useModal();
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const tableColStyle = (col: string) => {
+    if (col === 'contactId') return ' w-[10%]';
+    if (col === 'type') return ' w-[10%]';
+    if (col === 'userName') return ' w-[20%]';
+    if (col === 'createdAt') return ' w-[15%]';
+  };
+
+  const formatValue = (column: string, value: string | number) => {
+    if (column === 'createdAt' && typeof value === 'string')
+      return value.split('T')[0];
+    if (column === 'type') return contactTypeLabel[value as ContactType];
+    return value;
+  };
+
+  const handleItemClick = (id: number) => {
+    setSelected(id);
+    toggleModal();
+  };
+
+  return (
+    <div className='w-full h-full flex flex-col gap-20'>
+      <h1 className='text-30 font-semibold'>문의 관리</h1>
+      <table className='w-full table-fixed border-separate rounded-2xl overflow-hidden shadow-sm'>
+        <thead className={'bg-slate-300 text-center'}>
+          <tr>
+            {tableColumns.contact.map(column => (
+              <th
+                key={column}
+                className={`font-medium ${tableColStyle(column)}`}
+              >
+                {tableColumnMap.contact[column]}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {(isError || (!isLoading && list.length === 0)) && (
+            <tr>
+              <td colSpan={5} className='text-center py-60'>
+                데이터가 없습니다.
+              </td>
+            </tr>
+          )}
+          {list.map(item => (
+            <tr
+              key={item.contactId}
+              className='text-center cursor-pointer'
+              onClick={() => handleItemClick(item.contactId)}
+            >
+              {tableColumns.contact.map(column => (
+                <td key={column} className='truncate'>
+                  {formatValue(column, item[column])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <ContactDetailModal
+        id={selected}
+        isVisible={isVisible}
+        onClose={toggleModal}
+      />
+    </div>
+  );
+}

--- a/src/pages/Admin/constants/index.ts
+++ b/src/pages/Admin/constants/index.ts
@@ -1,3 +1,5 @@
+import { ContactTypeLabel } from '@/types/contact';
+
 import { TableColumnMap, TableColumns } from '../types';
 
 export const tableColumns: TableColumns = {
@@ -6,6 +8,7 @@ export const tableColumns: TableColumns = {
   survey: ['id', 'createdAt', 'class', 'name'],
   theory: ['id', 'class', 'file'],
   exam: ['id', 'createdAt', 'class', 'pdf', 'hwp'],
+  contact: ['contactId', 'type', 'title', 'userName', 'createdAt'],
 };
 
 export const tableColumnMap: TableColumnMap = {
@@ -38,4 +41,17 @@ export const tableColumnMap: TableColumnMap = {
     pdf: '과제 PDF',
     hwp: '제출용 HWP',
   },
+  contact: {
+    contactId: 'ID',
+    type: '문의 유형',
+    title: '문의 제목',
+    userName: '작성자',
+    createdAt: '작성일',
+  },
+};
+
+export const contactTypeLabel: ContactTypeLabel = {
+  class: '강의 의뢰',
+  training: '교사 연수 의뢰',
+  etc: '기타 문의',
 };

--- a/src/pages/Admin/types/index.ts
+++ b/src/pages/Admin/types/index.ts
@@ -1,3 +1,5 @@
+import { ContactSummary } from '@/types/contact';
+
 export interface SubClassData {
   title: string;
   orderNumber: number;
@@ -45,6 +47,7 @@ export interface TableColumns {
   survey: Array<keyof SurveyTableData>;
   theory: Array<keyof TheoryTableData>;
   exam: Array<keyof ExamTableData>;
+  contact: Array<keyof ContactSummary>;
 }
 
 export interface TableColumnMap {
@@ -76,5 +79,12 @@ export interface TableColumnMap {
     class: string;
     pdf: string;
     hwp: string;
+  };
+  contact: {
+    contactId: string;
+    type: string;
+    title: string;
+    userName: string;
+    createdAt: string;
   };
 }

--- a/src/routes/AdminRoutes.tsx
+++ b/src/routes/AdminRoutes.tsx
@@ -5,6 +5,7 @@ import AdminRoute from '@/components/AdminRoute';
 import Admin from '@/pages/Admin';
 import Assignment from '@/pages/Admin/Assignment';
 import Class from '@/pages/Admin/Class';
+import ContactList from '@/pages/Admin/Contact';
 import Exam from '@/pages/Admin/Exam';
 import Survey from '@/pages/Admin/Survey';
 import Theory from '@/pages/Admin/Theory';
@@ -41,6 +42,10 @@ export const adminRoutes: RouteObject[] = [
       {
         path: '/admin/theory',
         element: <Theory />,
+      },
+      {
+        path: '/admin/contact',
+        element: <ContactList />,
       },
     ],
   },

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,9 +1,22 @@
-import { post } from '@/libs/api';
-import { ContactForm, ContactType } from '@/types/contact';
+import { get, post } from '@/libs/api';
+import {
+  Contact,
+  ContactForm,
+  ContactSummary,
+  ContactType,
+} from '@/types/contact';
 
 class ContactApi {
   static async createContact(form: ContactForm, type: ContactType) {
     return post(`/contacts/`, { ...form, type });
+  }
+
+  static async getContactList() {
+    return get<ContactSummary[]>('/contacts/');
+  }
+
+  static async getContactDetail(id: number) {
+    return get<Contact>(`/contacts/${id}`);
   }
 }
 

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -7,3 +7,20 @@ export interface ContactForm {
 }
 
 export type ContactType = 'class' | 'training' | 'etc';
+
+export type ContactTypeLabel = {
+  [K in ContactType]: string;
+};
+
+export interface Contact {
+  type: ContactType;
+  contactId: number;
+  title: string;
+  userName: string;
+  phoneNumber: string;
+  email: string;
+  content: string;
+  createdAt: string;
+}
+
+export type ContactSummary = Omit<Contact, 'phoneNumber' | 'email' | 'content'>;


### PR DESCRIPTION
## 📝 개요

https://github.com/user-attachments/assets/4c3cba2c-caea-4ddd-9ed1-b8d886bd518f

- 데이터 없을 때
![image](https://github.com/user-attachments/assets/40148908-2f6f-4ad1-8949-66a617b0217d)


- 현재 상세 조회에서 `createdAt`이 null로 응답이 와서 작성일이 보이지 않습니다. 응답 수정되면 관련해서 코드 수정하겠습니다.
- 목록은 최신순 정렬로 변경될 예정입니다.

## 🚀 변경사항



## 🔗 관련 이슈

#75

## ➕ 기타

목록 조회에서 id 번호가 규칙적이지 않아서 게시판처럼 id 대신 그냥 No.를 넣을지 고민이 되네요. 의견이 궁금합니다!

<br/>
