### PR TITLE
feat: 페이징 공통 부분 구현 및 관리자 문의 목록 페이징 처리 추가

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -42,6 +42,8 @@ export default function Pagination({
     if (currentPage < start) setStart(prev => prev - pageCount);
   }, [currentPage, pageCount, start]);
 
+  if (totalPages === 1) return null;
+
   return (
     <div className='flex-row-center text-14 text-neutral-500 mt-30'>
       <ul className='flex-row-center [&>li]:h-30 [&>li]:leading-[30px]'>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,80 @@
+import { CaretLeft, CaretRight } from '@phosphor-icons/react';
+import { useState, useEffect, Fragment } from 'react';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
+
+interface Props {
+  currentPage: number; // 현재 페이지
+  totalElements: number; // 전체 데이터 개수
+  itemCountPerPage?: number; // 페이지 당 데이터 개수
+  pageCount?: number; // 한 번에 보여줄 페이지 개수 (e.g. 5, 10 ...)
+}
+
+export default function Pagination({
+  currentPage,
+  totalElements,
+  itemCountPerPage = 10,
+  pageCount = 5,
+}: Props) {
+  const [searchParams] = useSearchParams();
+  const { pathname } = useLocation();
+
+  const [start, setStart] = useState(1);
+  const totalPages = Math.ceil(totalElements / itemCountPerPage);
+  const noPrev = start === 1;
+  const noNext = start + pageCount - 1 >= totalPages;
+
+  const getUrl = (page: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('page', page.toString());
+    return `${pathname}?${params.toString()}`;
+  };
+
+  const pageNumberStyle = (isActive: boolean) =>
+    isActive
+      ? 'font-bold text-primary-400 border-neutral-200'
+      : ' border-neutral-200/0';
+
+  const moveLinkStyle = 'flex-row-center mx-10';
+
+  // 현재 보여줄 페이지 숫자 목록
+  useEffect(() => {
+    if (currentPage >= start + pageCount) setStart(prev => prev + pageCount);
+    if (currentPage < start) setStart(prev => prev - pageCount);
+  }, [currentPage, pageCount, start]);
+
+  return (
+    <div className='flex-row-center text-14 text-neutral-500 mt-30'>
+      <ul className='flex-row-center [&>li]:h-30 [&>li]:leading-[30px]'>
+        <li className={`${noPrev && 'invisible'}`}>
+          <Link to={getUrl(start - 1)} className={moveLinkStyle}>
+            <CaretLeft size={20} />
+            이전
+          </Link>
+        </li>
+        {[...Array(pageCount)].map((_, i) => (
+          <Fragment key={start + i}>
+            {start + i <= totalPages && (
+              <li>
+                <Link
+                  className={`block min-w-30 px-2 leading-[28px] text-center rounded-lg border-1 
+                    lg:hover:border-neutral-200 mx-2 ${pageNumberStyle(
+                      currentPage === start + i,
+                    )}`}
+                  to={getUrl(start + i)}
+                >
+                  {start + i}
+                </Link>
+              </li>
+            )}
+          </Fragment>
+        ))}
+        <li className={`${noNext && 'invisible'}`}>
+          <Link to={getUrl(start + pageCount)} className={moveLinkStyle}>
+            다음
+            <CaretRight size={20} />
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Admin/Contact/components/ContactDetailModal.tsx
+++ b/src/pages/Admin/Contact/components/ContactDetailModal.tsx
@@ -56,7 +56,7 @@ export default function ContactDetailModal({
                 <span>이메일</span> {data?.email}
               </p>
               <p className={textStyle}>
-                <span>작성일</span> {data?.createdAt}
+                <span>작성일</span> {data?.createdAt.split('T')[0]}
               </p>
               <hr className='my-12'></hr>
               <p className='text-18 font-semibold mb-8'>{data?.title}</p>

--- a/src/pages/Admin/Contact/hooks/useGetContactList.ts
+++ b/src/pages/Admin/Contact/hooks/useGetContactList.ts
@@ -1,14 +1,16 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import contactApi from '@/services/contact';
 
-export default function useGetContactList() {
+export default function useGetContactList(currentPage: number) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['contact'],
-    queryFn: () => contactApi.getContactList(),
+    queryKey: ['contact', currentPage],
+    queryFn: () => contactApi.getContactList(currentPage),
+    placeholderData: keepPreviousData,
   });
 
-  const list = data || [];
+  const list = data?.content || [];
+  const totalElements = data?.totalElements || 0;
 
-  return { list, isLoading, isError };
+  return { list, totalElements, isLoading, isError };
 }

--- a/src/pages/Admin/Contact/hooks/useGetContactList.ts
+++ b/src/pages/Admin/Contact/hooks/useGetContactList.ts
@@ -4,7 +4,7 @@ import contactApi from '@/services/contact';
 
 export default function useGetContactList(currentPage: number) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['contact', currentPage],
+    queryKey: ['contact', 'list', currentPage],
     queryFn: () => contactApi.getContactList(currentPage),
     placeholderData: keepPreviousData,
   });

--- a/src/pages/Admin/Contact/index.tsx
+++ b/src/pages/Admin/Contact/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
+import Pagination from '@/components/Pagination';
 import useModal from '@/hooks/useModal';
 import { ContactType } from '@/types/contact';
 
@@ -9,7 +11,10 @@ import ContactDetailModal from './components/ContactDetailModal';
 import useGetContactList from './hooks/useGetContactList';
 
 export default function ContactList() {
-  const { list, isLoading, isError } = useGetContactList();
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
+
+  const { list, totalElements, isLoading, isError } = useGetContactList(page);
   const { isVisible, toggleModal } = useModal();
   const [selected, setSelected] = useState<number | null>(null);
 
@@ -71,6 +76,7 @@ export default function ContactList() {
           ))}
         </tbody>
       </table>
+      <Pagination currentPage={page} totalElements={totalElements} />
       <ContactDetailModal
         id={selected}
         isVisible={isVisible}

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,4 +1,5 @@
 import { get, post } from '@/libs/api';
+import { PaginatedResponse } from '@/types';
 import {
   Contact,
   ContactForm,
@@ -11,8 +12,10 @@ class ContactApi {
     return post(`/contacts/`, { ...form, type });
   }
 
-  static async getContactList() {
-    return get<ContactSummary[]>('/contacts/');
+  static async getContactList(page: number) {
+    return get<PaginatedResponse<ContactSummary>>('/contacts/', {
+      params: { page },
+    });
   }
 
   static async getContactDetail(id: number) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,3 +18,16 @@ export type StrictPropsWithChildren<P = unknown> = P & {
 export type FieldRules<T extends FieldValues> = {
   [K in Path<T>]: RegisterOptions<T, K>;
 };
+
+/**
+ * 페이징 처리된 목록 응답 타입
+ * @example PaginatedResponse<Post>
+ */
+export type PaginatedResponse<T> = {
+  content: T[];
+  currentPage: number;
+  pageSize: number;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+};


### PR DESCRIPTION
## 📝 개요

- pagination

![pagination](https://github.com/user-attachments/assets/9173c3f7-1457-4511-9a21-9a18ae8bfb12)

**사용 예시**
```typescript
export default function ContactList() {
  const [searchParams] = useSearchParams();
  const page = Number(searchParams.get('page')) || 1;

  const { list, totalElements, isLoading, isError } = useGetContactList(page);

  return (
    <div className='w-full h-full flex flex-col gap-20'>
     (...)
      <Pagination currentPage={page} totalElements={totalElements} />
    </div>
  );
}
```

<br/>

- 관리자 문의 조회 페이징 적용

https://github.com/user-attachments/assets/ff1ed04f-142f-4999-8f05-2cd1192f9f4b

API 수정이 아직 안 되어서 1페이지 데이터만 계속 오고 있지만, query devtool 보시면 요청은 페이지에 맞게 들어가고 있습니다.

<br/>

## 🚀 변경사항

- 상세 조회 작성일(createdAt) 포맷팅

<br/>

## 🔗 관련 이슈

#99

<br/>

## ➕ 기타

전체 페이지가 하나일 때도 `Pagination` 컴포넌트를 렌더링 해야 할지 고민이 되네요. 전체 페이지가 하나면 1 링크 하나만 보여줘서 딱히 의미가 없을 것 같은데, 다른 분들 의견도 듣고 싶어서 일단 두었습니다. 코멘트 남겨주세요!

<br/>

