### PR TITLE
feat: 등업시키기 구현

### DIFF
--- a/src/pages/Community/Board.tsx
+++ b/src/pages/Community/Board.tsx
@@ -25,7 +25,8 @@ export default function Board() {
   }
 
   const isPostButtonVisible =
-    category === 'levelup' || (user && user.role !== '새싹');
+    (category === 'levelup' && user && user.role === '새싹') ||
+    (category !== 'levelup' && user && user.role !== '새싹');
 
   return (
     <div className='flex flex-col text-center mt-20'>

--- a/src/pages/Community/PostDetail.tsx
+++ b/src/pages/Community/PostDetail.tsx
@@ -55,7 +55,7 @@ export default function PostDetail() {
           />
         </>
       )}
-      {isLevelUpButtonVisible && <LevelUpButton />}
+      {isLevelUpButtonVisible && <LevelUpButton postId={Number(postId)} />}
       {post && post.commentAllow && <Comments />}
     </div>
   );

--- a/src/pages/Community/components/LevelUpButton.tsx
+++ b/src/pages/Community/components/LevelUpButton.tsx
@@ -1,10 +1,11 @@
-export default function LevelUpButton() {
+import useLevelUpMutation from '../hooks/useLevelUpMutation';
+
+export default function LevelUpButton({ postId }: { postId: number }) {
+  const mutation = useLevelUpMutation();
+
   const handleClick = () => {
     const ok = window.confirm('해당 멤버를 등업시키겠습니까?');
-    if (ok) {
-      // API 요청
-      alert('등업이 완료되었습니다.');
-    }
+    if (ok) mutation.mutate(postId);
   };
 
   return (

--- a/src/pages/Community/hooks/useLevelUpMutation.ts
+++ b/src/pages/Community/hooks/useLevelUpMutation.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import userApi from '@/services/user';
+
+export default function useLevelUpMutation() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (postId: number) => userApi.upgradeMembership(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['board', 'list', 4] });
+      alert('등업이 완료되었습니다.');
+      navigate('/community/levelup');
+    },
+    onError: () => {
+      alert('오류가 발생했습니다.');
+    },
+  });
+}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,4 +1,4 @@
-import { get, patch } from '@/libs/api';
+import { get, patch, post } from '@/libs/api';
 import { User, UserInfo } from '@/types/user';
 
 class UserApi {
@@ -14,6 +14,11 @@ class UserApi {
     return patch('/members/info', form, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
+  }
+
+  static async upgradeMembership(postId: number) {
+    // 1차 개발에선 학생 등업만 진행
+    return post(`/posts/${postId}/levelup/STUDENT`);
   }
 }
 


### PR DESCRIPTION
## 📝 개요

등업시키기 구현

- 1차 개발에서는 등업 게시판에서 **새싹 → 학생**으로의 등업만 신청할 수 있도록 합니다. 따라서 등업 게시판 내 글쓰기 버튼은 새싹 회원인 경우에만 렌더링됩니다. 
- 등업이 완료되면 백엔드에서 게시글을 삭제하기로 했습니다. ~~아직 반영되지는 않았습니다.~~ (반영 완료!)

https://github.com/user-attachments/assets/8e4bc46f-9d74-46b8-8fc7-0bbeaf0dfcab

<img src='https://github.com/user-attachments/assets/32184a9f-fca8-4600-a49e-c0d99bedeaf7' width='500px' />



## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#117

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
