### PR TITLE
feat: 로그아웃 시 쿼리 캐시 제거

### DIFF
--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { clearAllQueries } from '@/libs/react-query';
+import { clearSelectedQueries } from '@/libs/react-query';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 
@@ -18,8 +18,7 @@ export default function useLogout() {
       resetAuthState();
       resetUser();
       navigate('/');
-      // queryClient.removeQueries({ queryKey: ['user'] });
-      clearAllQueries('class');
+      clearSelectedQueries(['user', 'homework', 'survey']);
     } catch (error) {
       console.log('error with logout: ', error);
     }

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,12 +1,10 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { clearAllQueries } from '@/libs/react-query';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 
 export default function useLogout() {
-  const queryClient = useQueryClient();
-
   const { resetAuthState, resetUser } = useBoundStore(state => ({
     resetAuthState: state.resetAuthState,
     resetUser: state.resetUser,
@@ -20,7 +18,8 @@ export default function useLogout() {
       resetAuthState();
       resetUser();
       navigate('/');
-      queryClient.removeQueries({ queryKey: ['user'] });
+      // queryClient.removeQueries({ queryKey: ['user'] });
+      clearAllQueries('class');
     } catch (error) {
       console.log('error with logout: ', error);
     }

--- a/src/hooks/homework/useGetHomeworkList.ts
+++ b/src/hooks/homework/useGetHomeworkList.ts
@@ -9,7 +9,7 @@ interface UseGetHomeworksProps {
 
 function useGetHomeworkList({ page = 1, size = 10 }: UseGetHomeworksProps) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['homework-list', `${page}-${size}`],
+    queryKey: ['homework', 'list', `${page}-${size}`],
     queryFn: () => HomeworkApi.getHomeworkList({ page, size }),
   });
 

--- a/src/hooks/survey/useGetSurveyList.ts
+++ b/src/hooks/survey/useGetSurveyList.ts
@@ -17,7 +17,14 @@ function useGetSurveyList({
   sortDirection = 'desc',
 }: UseGetSurveyListProps) {
   const { data, isError, isLoading, error } = useQuery({
-    queryKey: ['surveyList', page, size, sortBy, sortDirection],
+    queryKey: [
+      'survey',
+      'list',
+      `page-${page}`,
+      `size-${size}`,
+      `sortBy-${sortBy}`,
+      `sortDirection-${sortDirection}`,
+    ],
     queryFn: () =>
       SurveyApi.getSurveyList({ page, size, sortBy, sortDirection }),
   });

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import memoize from 'memoize';
 
 import { BASE_URL } from '@/config';
-import { clearAllQueries } from '@/libs/react-query';
+import { clearSelectedQueries } from '@/libs/react-query';
 import useBoundStore from '@/stores';
 
 // access token 재발급
@@ -25,7 +25,7 @@ const reissueAccessToken = memoize(
         baseURL: BASE_URL,
         withCredentials: true,
       });
-      clearAllQueries('class');
+      clearSelectedQueries(['user', 'homework', 'survey']);
       return Promise.reject(refreshError);
     }
   },

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -2,9 +2,8 @@ import axios from 'axios';
 import memoize from 'memoize';
 
 import { BASE_URL } from '@/config';
+import { clearAllQueries } from '@/libs/react-query';
 import useBoundStore from '@/stores';
-
-import { queryClient } from './react-query';
 
 // access token 재발급
 const reissueAccessToken = memoize(
@@ -26,7 +25,7 @@ const reissueAccessToken = memoize(
         baseURL: BASE_URL,
         withCredentials: true,
       });
-      queryClient.removeQueries({ queryKey: ['user'] });
+      clearAllQueries('class');
       return Promise.reject(refreshError);
     }
   },

--- a/src/libs/react-query.ts
+++ b/src/libs/react-query.ts
@@ -9,3 +9,12 @@ const queryConfig: DefaultOptions = {
 };
 
 export const queryClient = new QueryClient({ defaultOptions: queryConfig });
+
+export const clearAllQueries = (except: string = '') => {
+  const allQueries = queryClient.getQueryCache().getAll();
+  allQueries.forEach(query => {
+    if (!query.queryKey.includes(except)) {
+      queryClient.removeQueries({ queryKey: query.queryKey });
+    }
+  });
+};

--- a/src/libs/react-query.ts
+++ b/src/libs/react-query.ts
@@ -10,11 +10,14 @@ const queryConfig: DefaultOptions = {
 
 export const queryClient = new QueryClient({ defaultOptions: queryConfig });
 
-export const clearAllQueries = (except: string = '') => {
-  const allQueries = queryClient.getQueryCache().getAll();
-  allQueries.forEach(query => {
-    if (!query.queryKey.includes(except)) {
-      queryClient.removeQueries({ queryKey: query.queryKey });
-    }
-  });
+export const clearSelectedQueries = (selectedQueries: string[] = []) => {
+  queryClient
+    .getQueryCache()
+    .getAll()
+    .filter(query =>
+      selectedQueries.some(selectedQuery =>
+        query.queryKey.includes(selectedQuery),
+      ),
+    )
+    .forEach(query => queryClient.removeQueries({ queryKey: query.queryKey }));
 };


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

로그아웃 시 쿼리 캐시 제거

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 로그아웃해도 로그인 하지 않은 유저는 접근할 수 없는 과제, 설문에 접근할 수 있는 문제가 있어서 수정햇습니다.
- 클래스 정보는 접근에 제한 없는 정보라 제외했습니다.

- 기존 유저 캐시만 지웠을 때

https://github.com/user-attachments/assets/c27a129c-02a3-4a1b-b180-d568ded83ecb




- 클래스 제외 모든 캐시 지운 경우


https://github.com/user-attachments/assets/443d0b40-f2da-46a9-bd66-bb1e3de2011b





## 🔗 관련 이슈

#139
<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->

- 혹시 게시판, 문의, 유저 쪽에서 부분에서 없앨 필요 없는 캐시가 있다면 수정하겠습니다.
