### PR TITLE
fix: 게시글 파일 삭제 예외 처리 추가 및 로직 수정 #132

### DIFF
--- a/src/pages/Community/hooks/usePostForm.ts
+++ b/src/pages/Community/hooks/usePostForm.ts
@@ -78,6 +78,7 @@ export default function usePostForm({ post, onSuccess }: usePostFormProps) {
   };
 
   const handleDeleteFileUrl = () => {
+    setFile(null);
     setFileUrl(null);
   };
 
@@ -95,14 +96,18 @@ export default function usePostForm({ post, onSuccess }: usePostFormProps) {
     formData.append('secret', data.secret.toString());
     formData.append('commentAllow', data.commentAllow.toString());
 
-    const prevFileUrl = fileUrl ?? '';
-    formData.append('file', file ?? prevFileUrl);
+    formData.append('file', file ?? '');
 
     // 게시글 수정
     if (post && postId) {
       // 파일을 삭제하는 경우
       if (post?.fileUrl && !fileUrl) {
-        communityApi.deletePostFile(Number(postId));
+        try {
+          await communityApi.deletePostFile(Number(postId));
+        } catch (error) {
+          alert('파일을 삭제할 수 없습니다.');
+          console.log(error);
+        }
       }
       const postUpdateData = { id: Number(postId), form: formData };
       updatePost.mutate(postUpdateData, {


### PR DESCRIPTION
## 📝 개요

게시글 파일 삭제 예외 처리 추가 및 로직 수정

https://github.com/user-attachments/assets/41b9f52b-c588-44ab-bf71-dce5599f505e

로컬 환경에서는 파일 추가, 수정, 삭제 전부 잘 되는 거 확인했습니다.

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#132

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
