### PR TITLE
fix: 프로필 이미지 수정 오류 해결

### DIFF
--- a/src/pages/My/components/EditProfile.tsx
+++ b/src/pages/My/components/EditProfile.tsx
@@ -13,6 +13,7 @@ export default function EditProfile({ user, onClose }: ProfileEditProps) {
     'relative w-148 h-148 border-1 border-zinc-300 rounded-md text-center flex-row-center text-14 text-neutral-600/35 lg:hover:border-primary-400 lg:hover:text-primary-400 transition-2 cursor-pointer overflow-hidden';
 
   const {
+    handleFileChange,
     imagePreview,
     resetImageFile,
     errors,
@@ -78,7 +79,7 @@ export default function EditProfile({ user, onClose }: ProfileEditProps) {
                 )}
               </label>
               <input
-                {...register('image')}
+                onChange={handleFileChange}
                 id='file-input'
                 type='file'
                 accept='image/*'

--- a/src/pages/My/hooks/useProfileForm.ts
+++ b/src/pages/My/hooks/useProfileForm.ts
@@ -105,7 +105,7 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
 
     // 이미지 처리
     const currentImageFile = await getCurrentImageFile();
-    formData.append('file', currentImageFile ?? new Blob());
+    if (currentImageFile) formData.append('file', currentImageFile);
 
     updateMutation.mutate(formData, {
       onSuccess: () => {

--- a/src/pages/My/hooks/useProfileForm.ts
+++ b/src/pages/My/hooks/useProfileForm.ts
@@ -12,7 +12,6 @@ interface IProfileFormInput {
   name: string;
   school: string;
   studentId: number;
-  image: FileList | null;
 }
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;
@@ -26,15 +25,12 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
   const {
     register,
     handleSubmit,
-    watch,
-    setValue,
     formState: { errors },
   } = useForm<IProfileFormInput>({
     defaultValues: {
       name: user.name,
       school: user.school ?? '',
       studentId: user.studentId ?? undefined,
-      image: null,
     },
   });
 
@@ -54,19 +50,14 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
       },
     },
     studentId: {},
-    image: {},
   };
 
-  const [imagePreview, setImagePreview] = useState('');
+  const [imagePreview, setImagePreview] = useState(user?.imageUrl);
   const [compressedImageFile, setCompressedImageFile] = useState<File | null>(
     null,
   );
 
-  const resetImageFile = () => {
-    setValue('image', null);
-    setImagePreview('');
-  };
-
+  // 이미지 File 압축 및 미리보기 추가
   const processImage = async (file: File) => {
     try {
       const compressedFile = await compressImage(file);
@@ -82,17 +73,28 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
     }
   };
 
-  const imageFile = watch('image');
-  if (imageFile && imageFile.length > 0) {
-    const file = imageFile[0];
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputFile = e.target.files?.[0];
+    if (!inputFile) return;
 
-    if (file.size > MAX_FILE_SIZE) {
+    if (inputFile.size > MAX_FILE_SIZE) {
       alert('이미지 파일의 크기는 2MB를 초과할 수 없습니다.');
-      resetImageFile();
-    } else {
-      processImage(file);
+      e.target.value = '';
+      return;
     }
-  }
+
+    processImage(inputFile);
+  };
+
+  const resetImageFile = () => {
+    setImagePreview('');
+  };
+
+  const getCurrentImageFile = async () => {
+    if (compressedImageFile) return compressedImageFile;
+    if (imagePreview && user.imageUrl) return convertURLtoFile(user.imageUrl);
+    return null;
+  };
 
   const updateProfile: SubmitHandler<IProfileFormInput> = async data => {
     const { name, school, studentId } = data;
@@ -102,13 +104,8 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
     formData.append('studentId', studentId.toString());
 
     // 이미지 처리
-    // 기존 이미지가 있고, 변경하지 않는 경우 url -> File 변환
-    // 기존 이미지가 없거나 기존 이미지를 삭제할 경우 new Blob
-    // 테스트 필요, CORS 있을 수 있음
-    const prevImageFile = user.imageUrl
-      ? await convertURLtoFile(user.imageUrl)
-      : new Blob();
-    formData.append('file', compressedImageFile ?? prevImageFile);
+    const currentImageFile = await getCurrentImageFile();
+    formData.append('file', currentImageFile ?? new Blob());
 
     updateMutation.mutate(formData, {
       onSuccess: () => {
@@ -124,6 +121,7 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
 
   return {
     imagePreview,
+    handleFileChange,
     resetImageFile,
     fieldRules,
     errors,

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -46,7 +46,7 @@ export default function MyPage() {
             <img
               src={user.imageUrl}
               alt='profile-img'
-              className='object-cover'
+              className='w-full h-full object-cover'
             />
           )}
         </div>

--- a/src/utils/convertURLtoFile.ts
+++ b/src/utils/convertURLtoFile.ts
@@ -1,5 +1,10 @@
+import axios from 'axios';
+
 export const convertURLtoFile = async (url: string) => {
-  const response = await fetch(url);
-  const blob = await response.blob();
+  const response = await axios.get(url, {
+    responseType: 'blob',
+    withCredentials: true,
+  });
+  const blob = response.data;
   return new File([blob], 'profile-image', { type: blob.type });
 };


### PR DESCRIPTION
## 📝 개요

fix: 프로필 이미지 수정 오류 해결

https://github.com/user-attachments/assets/4d45e55a-5d22-466a-9924-378e8be23bd4


## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#53

## ➕ 기타

현재 이미지 설정을 안 한 경우에도 서버에서 null 대신 url을 보내주고 계셔서 이미지 없을 때도 이미지가 있는 거처럼 뜹니다. 동천 님께서 수정하셨는데 아직 머지는 안 됐습니다!
