### PR TITLE
fix: 이미지 height 수정

### DIFF
--- a/src/pages/AboutUs/components/TeamInfo.tsx
+++ b/src/pages/AboutUs/components/TeamInfo.tsx
@@ -27,7 +27,7 @@ export default function TeamInfo() {
             <img
               src={teamImage[0]}
               alt='한서현'
-              className='block w-150 h-fit object-center scale-125 -mt-30 -ml-8'
+              className='block w-150 h-auto object-center scale-125 -mt-30 -ml-8'
             />
           </div>
           <div className={profileCardStyle}>

--- a/src/pages/Home/components/AboutUs.tsx
+++ b/src/pages/Home/components/AboutUs.tsx
@@ -45,7 +45,7 @@ export default function AboutUs() {
         </div>
         <img
           src={SNUImage}
-          className='lg:w-fit md:w-180 max-md:w-115 h-fit'
+          className='lg:w-fit md:w-180 max-md:w-115 h-auto'
           alt='snu-img'
         />
       </div>
@@ -63,7 +63,7 @@ export default function AboutUs() {
         <img
           src={Handshake}
           alt='handshake-img'
-          className='w-full max-w-[490px] h-fit px-45'
+          className='w-full max-w-[490px] h-auto px-45'
         />
       </div>
       <div

--- a/src/pages/Home/components/Achievements.tsx
+++ b/src/pages/Home/components/Achievements.tsx
@@ -24,7 +24,7 @@ export default function Achievements() {
               <img
                 src={a.imgUrl}
                 alt={`icon-${i + 1}`}
-                className={`${i === 2 ? 'w-36' : 'w-18'} h-fit`}
+                className={`${i === 2 ? 'w-36' : 'w-18'} h-18`}
               />
             </div>
             <div>


### PR DESCRIPTION
## 📝 개요

메인페이지, 회사 소개 페이지 일부 이미지 height 수정

<img src='https://github.com/user-attachments/assets/e72048ad-3813-4048-9797-ed61dffeb044' width="200px"/>


## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#155

## ➕ 기타

`height: fit-content`가 ios에서는 좀 다르게 동작하네요. h-auto 또는 px로 사이즈 지정했습니다.

<br/>
