### PR TITLE
fix: 새싹 등급 게시글 첨부 파일 다운로드 못 하게 수정

### DIFF
--- a/src/pages/Community/components/Comments.tsx
+++ b/src/pages/Community/components/Comments.tsx
@@ -48,8 +48,8 @@ export default function Comments({ postId }: { postId: number }) {
           <CommentForm postId={postId} mode='create' />
         ) : (
           <p className='text-center'>
-            <span className='text-primary-400 font-bold'>학생</span> 등급 이상만
-            댓글을 작성할 수 있어요.
+            <span className='text-primary-400 font-bold'>학생</span>
+            &nbsp;등급 이상만 댓글을 작성할 수 있습니다.
           </p>
         )}
       </div>

--- a/src/pages/Community/components/PostSection.tsx
+++ b/src/pages/Community/components/PostSection.tsx
@@ -1,6 +1,7 @@
 import { DownloadSimple } from '@phosphor-icons/react';
 import { Link } from 'react-router-dom';
 
+import useBoundStore from '@/stores';
 import { Post } from '@/types/community';
 
 import usePostMutation from '../hooks/usePostMutation';
@@ -23,6 +24,7 @@ export default function PostSection({
   isMine,
 }: PostSectionProps) {
   const { deletePost } = usePostMutation({ category });
+  const user = useBoundStore(state => state.user);
 
   const handleDelete = () => {
     const ok = window.confirm('게시글을 삭제하시겠습니까?');
@@ -31,11 +33,18 @@ export default function PostSection({
     }
   };
 
+  const handleDonwloadLink = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (user?.role === '새싹') {
+      e.preventDefault();
+      alert('학생 등급 이상만 파일을 다운 받을 수 있습니다.');
+    }
+  };
+
   return (
     <section>
       <hr className='border-1 border-black w-full' />
       <div
-        className='flex flex-col sm:flex-row justify-between px-20 py-4 
+        className='flex flex-col sm:flex-row justify-between px-10 md:px-20 py-4 
         sm:py-10 bg-gray-100 relative'
       >
         <h2 className='text-20 font-bold h-30'>{post?.title}</h2>
@@ -56,7 +65,7 @@ export default function PostSection({
         </div>
         <div className='flex items-center gap-12 ml-auto'>
           {post?.fileUrl && (
-            <Link to={post?.fileUrl}>
+            <Link to={post?.fileUrl} onClick={handleDonwloadLink}>
               <p className='flex-row-center gap-4 text-sm text-gray-500'>
                 파일 다운받기
                 <DownloadSimple className='mt-1 block' size={17} />


### PR DESCRIPTION
## 📝 개요

fix: 새싹 등급 게시글 첨부 파일 다운로드 못 하게 수정

https://github.com/user-attachments/assets/40576882-b97c-48a2-b6a6-0b25717d7bfc

첨부 파일 존재 여부는 알 수 있으면 좋을 것 같아서 alert 띄우는 방식으로 구현했습니다.

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#158 

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
