### PR TITLE
fix: 클래스 파일 타입, 다운로드 파일명 수정

### DIFF
--- a/src/pages/Admin/Class/components/FileItemDetails.tsx
+++ b/src/pages/Admin/Class/components/FileItemDetails.tsx
@@ -13,7 +13,7 @@ function FileItemDetails({ type, url }: FileItemDetailsProps) {
       </div>
       <a
         href={url}
-        download={getFileName(url)}
+        download={`${getFileName(url)}_${type}`}
         className={'text-14 text-primary-300'}
       >
         다운로드

--- a/src/pages/Admin/Class/components/GeneralFileItem.tsx
+++ b/src/pages/Admin/Class/components/GeneralFileItem.tsx
@@ -18,10 +18,10 @@ function GeneralFileItem({
   assignmentFileId: number;
 }) {
   const fileTypeStyle = () => {
-    if (assignmentType === 'THEORY') {
+    if (assignmentType === '이론') {
       return 'bg-green-50';
     }
-    if (assignmentType === 'EXAM') {
+    if (assignmentType === '시험') {
       return 'bg-blue-50';
     }
     return 'bg-yellow-50';
@@ -35,7 +35,7 @@ function GeneralFileItem({
 
   const { data: studentFile } = useGetSubClassStudentFile({
     assignmentAnswerFileId: generalFile?.assignmentAnswerFileId ?? 0,
-    enabled: assignmentType === 'EXAM' && !!generalFile?.assignmentAnswerFileId,
+    enabled: assignmentType === '시험' && !!generalFile?.assignmentAnswerFileId,
   });
 
   const { register, fieldRules, errors, onSubmit, reset } =
@@ -68,14 +68,14 @@ function GeneralFileItem({
         수정
       </button>
 
-      {assignmentType === 'EXAM' && (
+      {assignmentType === '시험' && (
         <>
           <button
             type={'button'}
             className={`col-span-2 text-13 text-center font-normal text-sky-800`}
             onClick={toggleModal}
           >
-            제출용 파일 업로드
+            학생용 파일 업로드
           </button>
           <StudentFileUploadModal
             isVisible={isVisible}
@@ -116,7 +116,7 @@ function GeneralFileItem({
 
       {studentFile && (
         <StudentFileItem
-          type={'제출용'}
+          type={'학생용'}
           assignmentAnswerFileId={generalFile.assignmentAnswerFileId}
           url={studentFile.filePresignedUrl}
         />

--- a/src/pages/Classes/[classId]/[subClassId]/index.tsx
+++ b/src/pages/Classes/[classId]/[subClassId]/index.tsx
@@ -10,6 +10,7 @@ import useGetSubClassFileList from '@/hooks/class/useGetSubClassFileList';
 import useModal from '@/hooks/useModal';
 import ExamContent from '@/pages/Classes/components/ExamContent';
 import useFileHandler from '@/pages/Classes/hooks/useFileHandler';
+import useBoundStore from '@/stores';
 
 function SubClass() {
   const buttonStyle =
@@ -46,23 +47,26 @@ function SubClass() {
     exam: false,
   });
 
+  const { user } = useBoundStore();
+
   useEffect(() => {
-    if (fileList) {
+    if (user && fileList) {
+      setFileState({ theory: false, data: false, exam: false });
       fileList.forEach(file => {
         const { assignmentType } = file;
-        if (assignmentType === 'THEORY') {
+        if (assignmentType === '이론') {
           setFileState(prev => ({
             ...prev,
             theory: true,
           }));
         }
-        if (assignmentType === 'DATA') {
+        if (assignmentType === '자료') {
           setFileState(prev => ({
             ...prev,
             data: true,
           }));
         }
-        if (assignmentType === 'EXAM') {
+        if (assignmentType === '시험') {
           setFileState(prev => ({
             ...prev,
             exam: true,
@@ -70,7 +74,7 @@ function SubClass() {
         }
       });
     }
-  }, [fileList]);
+  }, [fileList, user, classId, subClassId]);
 
   return (
     <>
@@ -82,7 +86,7 @@ function SubClass() {
         {fileState.theory && (
           <button
             className={buttonStyle}
-            onClick={() => handleDownloadFile('THEORY')}
+            onClick={() => handleDownloadFile('이론')}
           >
             <div className={iconWrapperStyle}>
               <Book className={iconStyle} />
@@ -94,7 +98,7 @@ function SubClass() {
         {fileState.data && (
           <button
             className={buttonStyle}
-            onClick={() => handleDownloadFile('DATA')}
+            onClick={() => handleDownloadFile('자료')}
           >
             <div className={iconWrapperStyle}>
               <Paperclip className={iconStyle} />

--- a/src/pages/Classes/components/ExamContent.tsx
+++ b/src/pages/Classes/components/ExamContent.tsx
@@ -17,7 +17,7 @@ function ExamContent({ examFileUrl, studentFileId }: ExamContentProps) {
       <div className={'w-full flex-col-center sm:flex-row-center gap-30'}>
         <a
           href={examFileUrl}
-          download={getFileName(examFileUrl ?? '')}
+          download={`${getFileName(examFileUrl ?? '')}_시험`}
           className={
             'p-10 text-20 border-2 border-primary-300 rounded-lg hover:bg-primary-300 hover:text-white transition ease-in-out delay-50'
           }
@@ -27,7 +27,7 @@ function ExamContent({ examFileUrl, studentFileId }: ExamContentProps) {
         {examStudentFile && (
           <a
             href={examStudentFile.filePresignedUrl}
-            download={getFileName(examStudentFile.filePresignedUrl)}
+            download={`${getFileName(examStudentFile.filePresignedUrl)}_학생용`}
             className={
               'p-10 text-20 border-2 border-primary-300 rounded-lg hover:bg-primary-300 hover:text-white transition ease-in-out delay-50'
             }

--- a/src/pages/Classes/hooks/useFileHandler.ts
+++ b/src/pages/Classes/hooks/useFileHandler.ts
@@ -37,7 +37,7 @@ function useFileHandler({
     return fileList?.find(file => file.assignmentType === type);
   };
 
-  const handleDownloadFile = (type: 'THEORY' | 'DATA') => {
+  const handleDownloadFile = (type: '이론' | '자료') => {
     if (user?.role === '관리자') {
       const file = findFile(type);
       if (!file) {
@@ -56,14 +56,14 @@ function useFileHandler({
   };
 
   const handleExamClick = () => {
-    const file = findFile('EXAM');
+    const file = findFile('시험');
     if (!file) {
       setModalMessage('시험 정보가 없습니다.');
       toggleModal();
       return;
     }
     setContentState({
-      generalType: 'EXAM',
+      generalType: '시험',
       generalFileId: file.assignmentFileId,
     });
     setOpenExam(prev => !prev);
@@ -75,14 +75,15 @@ function useFileHandler({
 
   useEffect(() => {
     if (
-      contentState.generalType === 'THEORY' ||
-      contentState.generalType === 'DATA'
+      contentState.generalType === '이론' ||
+      contentState.generalType === '자료'
     ) {
       // 파일 다운로드
-      const linkEle = document.createElement('a');
-      linkEle.href = generalFile?.filePresignedUrl ?? '';
-      linkEle.download = getFileName(generalFile?.filePresignedUrl ?? '') ?? '';
-      linkEle.click();
+      const fileName = `${getFileName(generalFile?.filePresignedUrl ?? '')}_${contentState.generalType}`;
+      const a = document.createElement('a');
+      a.href = generalFile?.filePresignedUrl || '';
+      a.download = fileName;
+      a.click();
     }
   }, [generalFile, contentState]);
 

--- a/src/pages/Classes/types/index.ts
+++ b/src/pages/Classes/types/index.ts
@@ -33,6 +33,6 @@ export interface TempExamInfoMap {
 }
 
 export interface SubClassContentState {
-  generalType: 'THEORY' | 'DATA' | 'EXAM' | null;
+  generalType: '이론' | '자료' | '시험' | null;
   generalFileId: number | null;
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

클래스 파일 타입, 다운로드 파일명 수정

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- admin에서 업로드 시에는 영어로 (THEORY, DATA, EXAM), 값을 받을 때는 (이론, 자료, 시험) 으로 받는 것으로 정했습니다.
- 파일 download시 뒤에 `클래스명_타입` 으로 수정했습니다.
  -  a태그의 download 속성이 동일 출처에서만 작동해서 vite 개발서버에서는 확인할 수가 없습니다. develop에 합쳐지면 다시 확인하겠습니다.

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->
#165 

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
