### PR TITLE
refactor: 400번대 API 오류 예외 처리 개선

### DIFF
--- a/src/components/AccessError.tsx
+++ b/src/components/AccessError.tsx
@@ -4,7 +4,8 @@ import { isEndWithConsonant } from '@/utils/isEndWithConsonant';
 
 interface AccessErrorProps {
   type: string;
-  errorCode: number;
+  status: number;
+  errorCode?: string | null;
   linkUrl?: string;
   linkString?: string;
   isPrevPageDirection?: boolean;
@@ -12,6 +13,7 @@ interface AccessErrorProps {
 
 export default function AccessError({
   type,
+  status,
   errorCode,
   linkUrl,
   linkString,
@@ -24,11 +26,15 @@ export default function AccessError({
   return (
     <div className='flex-col-center h-[500px] gap-10 py-120'>
       <p className='text-center'>
-        {errorCode === 401 &&
+        {status === 401 &&
           `로그인 후 ${type}${isEndWithConsonant(type) ? '을' : '를'} 열람할 수 있습니다.`}
-        {errorCode === 403 &&
+        {status === 403 &&
+          errorCode !== 'ADMIN_OR_WRITER_PERMISSION' &&
           `학생 등급 이상만 ${type}${isEndWithConsonant(type) ? '을' : '를'} 열람할 수 있습니다.`}
-        {errorCode === 404 &&
+        {status === 403 &&
+          errorCode === 'ADMIN_OR_WRITER_PERMISSION' &&
+          `${type}${isEndWithConsonant(type) ? '은' : '는'} 작성자와 관리자만 열람할 수 있습니다.`}
+        {status === 404 &&
           `${type}${isEndWithConsonant(type) ? '이' : '가'} 존재하지 않습니다.`}
       </p>
       {linkUrl && linkString && (

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { useForm, FieldValues } from 'react-hook-form';
 
+import { ApiError } from '@/libs/errors';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 import { FieldRules } from '@/types';
@@ -50,10 +50,10 @@ export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
       onSuccess();
     },
     onError: error => {
-      if (isAxiosError(error) && error.response?.status) {
-        const { status } = error.response;
-        if (status === 400) alert('아이디 또는 비밀번호가 일치하지 않습니다.');
-      }
+      if (error instanceof ApiError && error.status) {
+        if (error.status === 400)
+          alert('아이디 또는 비밀번호가 일치하지 않습니다.');
+      } else alert('로그인에 실패했습니다.');
       console.log(error);
     },
   });

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -50,7 +50,7 @@ export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
       onSuccess();
     },
     onError: error => {
-      if (error instanceof ApiError && error.status) {
+      if (error instanceof ApiError) {
         if (error.status === 400)
           alert('아이디 또는 비밀번호가 일치하지 않습니다.');
       } else alert('로그인에 실패했습니다.');

--- a/src/hooks/auth/useRegisterForm.ts
+++ b/src/hooks/auth/useRegisterForm.ts
@@ -1,7 +1,7 @@
-import { isAxiosError } from 'axios';
 import { useState } from 'react';
 import { useForm, FieldValues } from 'react-hook-form';
 
+import { ApiError } from '@/libs/errors';
 import auth from '@/services/auth';
 import { FieldRules } from '@/types';
 import { UseAuthFormProps } from '@/types/auth';
@@ -59,13 +59,9 @@ export default function useRegisterForm({ onSuccess }: UseAuthFormProps) {
       alert('회원가입이 완료되었습니다.');
       onSuccess();
     } catch (error) {
-      if (isAxiosError(error) && error.response?.status) {
-        const { status } = error.response;
-        const {
-          result: { message },
-        } = error.response.data;
-        if (status === 409) alert(message);
-      }
+      if (error instanceof ApiError && error.status) {
+        if (error.status === 409) alert(error.message);
+      } else alert('로그인에 실패했습니다.');
       console.log(error);
     } finally {
       setIsRegisterButtonDisabled(false);

--- a/src/hooks/auth/useRegisterForm.ts
+++ b/src/hooks/auth/useRegisterForm.ts
@@ -59,7 +59,7 @@ export default function useRegisterForm({ onSuccess }: UseAuthFormProps) {
       alert('회원가입이 완료되었습니다.');
       onSuccess();
     } catch (error) {
-      if (error instanceof ApiError && error.status) {
+      if (error instanceof ApiError) {
         if (error.status === 409) alert(error.message);
       } else alert('로그인에 실패했습니다.');
       console.log(error);

--- a/src/hooks/homework/useGetHomework.ts
+++ b/src/hooks/homework/useGetHomework.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
+import { ApiError } from '@/libs/errors';
 import HomeworkApi from '@/services/homework';
 import useBoundStore from '@/stores';
 
@@ -25,9 +25,10 @@ function useGetHomework({ homeworkId }: UseGetHomeworkProps) {
     }
   }, [user, accessToken]);
 
-  const errorCode = isAxiosError(error) ? error.response?.status : null;
+  const errorStatus =
+    error instanceof ApiError && error.status ? error.status : null;
 
-  return { data, isLoading, isError, errorCode };
+  return { data, isLoading, isError, errorStatus };
 }
 
 export default useGetHomework;

--- a/src/hooks/homework/useGetHomework.ts
+++ b/src/hooks/homework/useGetHomework.ts
@@ -25,8 +25,7 @@ function useGetHomework({ homeworkId }: UseGetHomeworkProps) {
     }
   }, [user, accessToken]);
 
-  const errorStatus =
-    error instanceof ApiError && error.status ? error.status : null;
+  const errorStatus = error instanceof ApiError ? error.status : null;
 
   return { data, isLoading, isError, errorStatus };
 }

--- a/src/hooks/survey/useGetSurvey.ts
+++ b/src/hooks/survey/useGetSurvey.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
+import { ApiError } from '@/libs/errors';
 import SurveyApi from '@/services/survey';
 import useBoundStore from '@/stores';
 
@@ -25,9 +25,10 @@ function useGetSurvey({ surveyId }: UseGetSurveyProps) {
     }
   }, [user, accessToken]);
 
-  const errorCode = isAxiosError(error) ? error.response?.status : null;
+  const errorStatus =
+    error instanceof ApiError && error.status ? error.status : null;
 
-  return { data, isLoading, isError, errorCode };
+  return { data, isLoading, isError, errorStatus };
 }
 
 export default useGetSurvey;

--- a/src/hooks/survey/useGetSurvey.ts
+++ b/src/hooks/survey/useGetSurvey.ts
@@ -25,8 +25,7 @@ function useGetSurvey({ surveyId }: UseGetSurveyProps) {
     }
   }, [user, accessToken]);
 
-  const errorStatus =
-    error instanceof ApiError && error.status ? error.status : null;
+  const errorStatus = error instanceof ApiError ? error.status : null;
 
   return { data, isLoading, isError, errorStatus };
 }

--- a/src/hooks/survey/useGetSurveyList.ts
+++ b/src/hooks/survey/useGetSurveyList.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
+import { ApiError } from '@/libs/errors';
 import SurveyApi from '@/services/survey';
 
 interface UseGetSurveyListProps {
@@ -32,14 +32,15 @@ function useGetSurveyList({
   const list = data?.content || [];
   const totalElements = data?.totalElements || 0;
 
-  const errorCode = isAxiosError(error) ? error.response?.status : null;
+  const errorStatus =
+    error instanceof ApiError && error.status ? error.status : null;
 
   return {
     list,
     totalElements,
     isError,
     isLoading,
-    errorCode,
+    errorStatus,
   };
 }
 

--- a/src/hooks/survey/useGetSurveyList.ts
+++ b/src/hooks/survey/useGetSurveyList.ts
@@ -32,8 +32,7 @@ function useGetSurveyList({
   const list = data?.content || [];
   const totalElements = data?.totalElements || 0;
 
-  const errorStatus =
-    error instanceof ApiError && error.status ? error.status : null;
+  const errorStatus = error instanceof ApiError ? error.status : null;
 
   return {
     list,

--- a/src/libs/errors.ts
+++ b/src/libs/errors.ts
@@ -1,10 +1,10 @@
 /** @description 400번대 서버 api 에러 */
 export class ApiError extends Error {
-  status: number | undefined;
+  status: number;
 
   errorCode: string | undefined;
 
-  constructor(message: string, status?: number, errorCode?: string) {
+  constructor(message: string, status: number, errorCode?: string) {
     super(message);
     this.name = 'Api Error';
     this.status = status;

--- a/src/libs/errors.ts
+++ b/src/libs/errors.ts
@@ -1,0 +1,13 @@
+/** @description 400번대 서버 api 에러 */
+export class ApiError extends Error {
+  status: number | undefined;
+
+  errorCode: string | undefined;
+
+  constructor(message: string, status?: number, errorCode?: string) {
+    super(message);
+    this.name = 'Api Error';
+    this.status = status;
+    this.errorCode = errorCode;
+  }
+}

--- a/src/pages/Admin/Class/hooks/useClassRegisterForm.ts
+++ b/src/pages/Admin/Class/hooks/useClassRegisterForm.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { ApiError } from '@/libs/errors';
 import AdminClassApi from '@/services/admin/class';
 import { FieldRules } from '@/types';
 
@@ -66,8 +66,8 @@ function useClassRegisterForm({ onClose }: UseClassRegisterFormProps) {
       },
       onError: error => {
         alert('클래스 등록에 실패했습니다.');
-        if (isAxiosError(error)) {
-          console.error(error.response?.data.result.message);
+        if (error instanceof ApiError) {
+          console.error(error.message);
           return;
         }
         console.error(error);

--- a/src/pages/Admin/Class/hooks/useSubClassRegisterForm.ts
+++ b/src/pages/Admin/Class/hooks/useSubClassRegisterForm.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { ApiError } from '@/libs/errors';
 import AdminClassApi from '@/services/admin/class';
 import { FieldRules } from '@/types';
 
@@ -67,8 +67,8 @@ function useSubClassRegisterForm({ onClose }: UseSubClassRegisterFormProps) {
       },
       onError: error => {
         alert('서브 클래스 등록에 실패했습니다.');
-        if (isAxiosError(error)) {
-          console.error(error.response?.data.result.message);
+        if (error instanceof ApiError) {
+          console.error(error.message);
           return;
         }
         console.error(error);

--- a/src/pages/Community/PostDetail.tsx
+++ b/src/pages/Community/PostDetail.tsx
@@ -18,15 +18,17 @@ export default function PostDetail() {
   const { category, postId } = useParams();
   const user = useBoundStore(state => state.user);
   const isPostIdNumeric = !Number.isNaN(Number(postId));
-  const { data: post, isFetched, errorCode } = useGetPost(postId ?? '');
-  const isForbidden = errorCode === 403;
+  const {
+    data: post,
+    errorResult: { status, code },
+  } = useGetPost(postId ?? '');
 
   // 경로 예외 처리
   if (!category || !(category in boardMetaData))
     return <Navigate to='/community' replace />;
 
   // postId 패턴 및 API 요청 예외 처리
-  if (!isPostIdNumeric || (isFetched && !isForbidden && !post && user)) {
+  if (!isPostIdNumeric || (status && status >= 500 && !post)) {
     alert('게시글 정보를 찾을 수 없습니다.');
     return <Navigate to={`/community/${category}`} replace />;
   }
@@ -41,12 +43,15 @@ export default function PostDetail() {
       <Head
         title={`${post?.title ? `${post.title} | ` : ''}ABCDEdu 커뮤니티`}
       />
-      {isFetched && isForbidden && (
-        <AccessError type='게시글' isPrevPageDirection errorCode={errorCode} />
+      {status && status >= 400 && (
+        <AccessError
+          type={status === 403 ? '비밀글' : '게시글'}
+          isPrevPageDirection
+          status={status}
+          errorCode={code}
+        />
       )}
-      {!user && (
-        <AccessError type='게시글' isPrevPageDirection errorCode={401} />
-      )}
+      {!user && <AccessError type='게시글' isPrevPageDirection status={401} />}
       {post && (
         <>
           <PostSection

--- a/src/pages/Community/hooks/useGetPost.ts
+++ b/src/pages/Community/hooks/useGetPost.ts
@@ -16,8 +16,7 @@ export default function useGetPost(postId: string) {
     enabled: /^\d+$/.test(postId) && !!accessToken,
   });
 
-  const status =
-    error instanceof ApiError && error.status ? error.status : null;
+  const status = error instanceof ApiError ? error.status : null;
   const code =
     error instanceof ApiError && error.errorCode ? error.errorCode : null;
 

--- a/src/pages/Community/hooks/useGetPost.ts
+++ b/src/pages/Community/hooks/useGetPost.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
+import { ApiError } from '@/libs/errors';
 import communityApi from '@/services/community';
 import useBoundStore from '@/stores';
 
@@ -16,10 +16,10 @@ export default function useGetPost(postId: string) {
     enabled: /^\d+$/.test(postId) && !!accessToken,
   });
 
-  const errorCode =
-    isAxiosError(error) && error.response?.status
-      ? error.response?.status
-      : null;
+  const status =
+    error instanceof ApiError && error.status ? error.status : null;
+  const code =
+    error instanceof ApiError && error.errorCode ? error.errorCode : null;
 
-  return { data, isLoading, isFetched, errorCode };
+  return { data, isLoading, isFetched, errorResult: { status, code } };
 }

--- a/src/pages/Community/hooks/usePostMutation.ts
+++ b/src/pages/Community/hooks/usePostMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 
+import { ApiError } from '@/libs/errors';
 import communityApi from '@/services/community';
 
 import { boardMetaData, Category } from '../constants/communityInfo';
@@ -21,14 +21,8 @@ export default function usePostMutation({
   const navigate = useNavigate();
 
   const handleAPIError = (error: Error) => {
-    if (isAxiosError(error) && error.response?.status) {
-      const { status } = error.response;
-      if (status >= 400) {
-        const {
-          result: { message },
-        } = error.response.data;
-        alert(message);
-      }
+    if (error instanceof ApiError && error.status) {
+      console.log(error.message);
     }
     console.log(error);
   };
@@ -43,6 +37,7 @@ export default function usePostMutation({
     },
     onError: error => {
       handleAPIError(error);
+      alert('게시글 등록에 실패했습니다.');
     },
   });
 
@@ -61,6 +56,7 @@ export default function usePostMutation({
     },
     onError: error => {
       handleAPIError(error);
+      alert('게시글 수정에 실패했습니다.');
     },
   });
 
@@ -72,6 +68,7 @@ export default function usePostMutation({
     },
     onError: error => {
       handleAPIError(error);
+      alert('게시글 삭제에 실패했습니다.');
     },
   });
 

--- a/src/pages/Community/hooks/usePostMutation.ts
+++ b/src/pages/Community/hooks/usePostMutation.ts
@@ -21,10 +21,8 @@ export default function usePostMutation({
   const navigate = useNavigate();
 
   const handleAPIError = (error: Error) => {
-    if (error instanceof ApiError && error.status) {
-      console.log(error.message);
-    }
-    console.log(error);
+    if (error instanceof ApiError) console.log(error.message);
+    else console.log(error);
   };
 
   const createPost = useMutation({

--- a/src/pages/Contact/hooks/useContactForm.ts
+++ b/src/pages/Contact/hooks/useContactForm.ts
@@ -45,6 +45,7 @@ export default function useContactForm({
       onSuccess();
       reset();
     } catch (error) {
+      alert('문의 등록에 실패했습니다.');
       console.log(error);
     } finally {
       setIsSubmitButtonDisabled(false);

--- a/src/pages/Homework/components/HomeworkForm.tsx
+++ b/src/pages/Homework/components/HomeworkForm.tsx
@@ -17,7 +17,7 @@ function HomeworkForm({ homeworkId }: HomeworkFormProps) {
     data: homework,
     isLoading,
     isError,
-    errorCode,
+    errorStatus,
   } = useGetHomework({ homeworkId });
 
   const { register, errors, reset, onSubmit } = useHomeworkForm({
@@ -32,11 +32,11 @@ function HomeworkForm({ homeworkId }: HomeworkFormProps) {
     return <HomeworkLoading />;
   }
 
-  if (errorCode) {
+  if (errorStatus) {
     return (
       <AccessError
         type={'과제'}
-        errorCode={errorCode}
+        status={errorStatus}
         linkUrl={'/'}
         linkString={'홈으로'}
       />

--- a/src/pages/My/hooks/useProfileMutation.ts
+++ b/src/pages/My/hooks/useProfileMutation.ts
@@ -11,11 +11,9 @@ export default function useProfileMutation() {
       queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: error => {
-      if (error instanceof ApiError && error.status) {
-        console.log(error.message);
-      }
+      if (error instanceof ApiError) console.log(error.message);
+      else console.log(error);
       alert('프로필 수정에 실패했습니다.');
-      console.log(error);
     },
   });
 }

--- a/src/pages/My/hooks/useProfileMutation.ts
+++ b/src/pages/My/hooks/useProfileMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
+import { ApiError } from '@/libs/errors';
 import userApi from '@/services/user';
 
 export default function useProfileMutation() {
@@ -11,10 +11,10 @@ export default function useProfileMutation() {
       queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: error => {
-      if (isAxiosError(error) && error.response?.status) {
-        const { status } = error.response;
-        if (status === 400) alert('잘못된 요청');
+      if (error instanceof ApiError && error.status) {
+        console.log(error.message);
       }
+      alert('프로필 수정에 실패했습니다.');
       console.log(error);
     },
   });

--- a/src/pages/Survey/components/SurveyForm.tsx
+++ b/src/pages/Survey/components/SurveyForm.tsx
@@ -16,7 +16,7 @@ function SurveyForm({ surveyId }: SurveyFormProps) {
     data: survey,
     isError,
     isLoading,
-    errorCode,
+    errorStatus,
   } = useGetSurvey({ surveyId });
 
   const { register, errors, onSubmit } = useSurveyForm({
@@ -27,11 +27,11 @@ function SurveyForm({ surveyId }: SurveyFormProps) {
     return <SurveyLoading />;
   }
 
-  if (errorCode) {
+  if (errorStatus) {
     return (
       <AccessError
         type={'설문'}
-        errorCode={errorCode}
+        status={errorStatus}
         linkUrl={'/'}
         linkString={'홈으로'}
       />


### PR DESCRIPTION
## 📝 개요

- 서버에서 주는 다음과 같은 형태의 구조화된 error.response.data를 조금 더 편하게 사용하기 위해 `ApiError` 클래스를 정의하고 이를 interceptor에서 400번대 오류일 경우 반환하도록 했습니다.

```json
{
    "resultCode": "ERROR",
    "result": {
        "errorCode": "STUDENT_VALID_PERMISSION",
        "message": "학생등급 이상 가능"
    }
}
```

- 기존 `AccessError`에서 403 오류에 대한 메시지를 학생 권한 이상(STUDENT_VALID_PERMISSION)으로만 처리하고 있었습니다. 비밀글과 같은 다른 errorCode에 대해서는 다른 메시지를 보여줘야 하기 때문에 AccessError props를 수정했습니다

```
기존 errorCode -> status (e.g. 400, 403 ...) 로 props명 변경
errorCode - 'STUDENT_VALID_PERMISSION', 'ADMIN_OR_WRITER_PERMISSION'과 같은 서버 error result의 errorCode
```

일단 현재는 403 예외에 대해 관리자 only는 redirect로 처리, AccessError에서는 **403 errorCode가 학생 권한 이상, 본인 또는 관리자 권한만 존재한다고 가정**하고 로직을 작성했습니다. ~~만약 이 외에도 403 errorCode가 더 존재한다면 수정될 수 있습니다. 현재 수정 님이 관련해서 확인해본다고 하셨습니다!~~
+) 이 외에 다른 403 errorCode는 없도록 설정하겠다고 하시네요!


interceptor에서 예외 응답 타입이 변경되면서 hook의 api 예외 처리 부분을 수정했습니다.


## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#179

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
