### PR TITLE
fix: 시험파일 pdf 여부에 따라 버튼, viewer 조건부 렌더링 추가

### DIFF
--- a/src/pages/Classes/components/ExamContent.tsx
+++ b/src/pages/Classes/components/ExamContent.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import useGetSubClassStudentFile from '@/hooks/class/useGetSubClassStudentFile';
 import useGetPdfUrl from '@/pages/Classes/hooks/useGetPdfUrl';
 import useBoundStore from '@/stores';
+import { getFileName } from '@/utils/getFileName';
 
 interface ExamContentProps {
   examFileUrl: string | undefined;
@@ -12,6 +13,8 @@ interface ExamContentProps {
 function ExamContent({ examFileUrl, studentFileId }: ExamContentProps) {
   const buttonStyle =
     'p-5 md:p-10 text-18 md:text-20 border-2 border-primary-300 rounded-lg hover:bg-primary-300 hover:text-white transition ease-in-out delay-50';
+
+  const [isPdf, setIsPdf] = useState(false);
 
   const { data: examStudentFile } = useGetSubClassStudentFile({
     assignmentAnswerFileId: studentFileId,
@@ -47,9 +50,21 @@ function ExamContent({ examFileUrl, studentFileId }: ExamContentProps) {
     }
   }, [handleIntersect, headerRef]);
 
+  useEffect(() => {
+    if (examFileUrl && getFileName(examFileUrl)?.split('.').pop() === 'pdf') {
+      setIsPdf(true);
+    }
+  }, [examFileUrl]);
+
   return (
     <div className={'w-full pb-50 flex-col-center gap-30'}>
       <div className={'w-full flex-col-center sm:flex-row-center gap-30'}>
+        {!isPdf && (
+          <a href={examFileUrl} download className={buttonStyle}>
+            시험 파일 다운로드
+          </a>
+        )}
+
         {examStudentFile && (
           <a
             href={examStudentFile.filePresignedUrl}
@@ -60,16 +75,21 @@ function ExamContent({ examFileUrl, studentFileId }: ExamContentProps) {
           </a>
         )}
       </div>
-      <div
-        className={'min-w-[300px] w-[85%] h-[500px] sm:h-[700px] md:h-[900px]'}
-      >
-        <iframe
-          ref={iframeRef}
-          src={pdfUrl}
-          title={'exam'}
-          className={'w-full h-full'}
-        />
-      </div>
+
+      {isPdf && (
+        <div
+          className={
+            'min-w-[300px] w-[85%] h-[500px] sm:h-[700px] md:h-[900px]'
+          }
+        >
+          <iframe
+            ref={iframeRef}
+            src={pdfUrl}
+            title={'exam'}
+            className={'w-full h-full'}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

시험파일 pdf 여부에 따라 버튼, viewer 조건부 렌더링 추가

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 실제 prod에서 시험파일에 hwp 파일만 넣는 경우도 있음을 확인하고 수정했습니다.

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->

hotfix로 바로 머지하겠습니다.
