### PR TITLE
fix: 메인페이지 모바일 UI 수정, 게시글 및 댓글 한국 시간 적용

### DIFF
--- a/src/pages/Community/components/CommentCard.tsx
+++ b/src/pages/Community/components/CommentCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Comment } from '@/types/community';
+import { formatDate } from '@/utils/formatDate';
 
 import useCommentMutation from '../hooks/useCommentMutation';
 
@@ -37,7 +38,7 @@ export default function CommentCard({
         <div className='flex items-center gap-2'>
           <p className='font-semibold mr-4 text-sm'>{comment.writerName}</p>
           <p className='text-xs text-gray-500'>
-            {comment.createdAt.split('T')[0]}
+            {formatDate(comment.createdAt, true)}
           </p>
         </div>
         {isMine && (

--- a/src/pages/Community/components/List.tsx
+++ b/src/pages/Community/components/List.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Pagination from '@/components/Pagination';
 import useBoundStore from '@/stores';
 import { PostSummary } from '@/types/community';
+import { formatDate } from '@/utils/formatDate';
 
 interface ListProps {
   isLoading: boolean;
@@ -81,7 +82,7 @@ export default function List({
                   </Link>
                 </td>
                 <td className='max-md:hidden px-5 py-10 text-14 text-gray-500'>
-                  <p>{post.createdAt.split('T')[0]}</p>
+                  <p>{formatDate(post.createdAt)}</p>
                 </td>
                 <td className='max-md:hidden px-5 py-10 text-14 text-gray-500'>
                   <p>{post.viewCount}</p>

--- a/src/pages/Community/components/PostSection.tsx
+++ b/src/pages/Community/components/PostSection.tsx
@@ -2,6 +2,7 @@ import { DownloadSimple } from '@phosphor-icons/react';
 import { Link } from 'react-router-dom';
 
 import { Post } from '@/types/community';
+import { formatDate } from '@/utils/formatDate';
 
 import usePostMutation from '../hooks/usePostMutation';
 
@@ -50,7 +51,9 @@ export default function PostSection({
             {post?.writer ?? '사용자'}
           </p>
           <p className='text-gray-400 relative text-sm pipe-after'>
-            {post?.createdAt ? post.createdAt.split('T')[0] : 'YYYY-MM-DD'}
+            {post?.createdAt
+              ? formatDate(post.createdAt, true)
+              : 'YYYY-MM-DD hh:mm'}
           </p>
           <p className='text-gray-400 text-sm'>{`조회 ${post?.viewCount ?? 0}`}</p>
         </div>

--- a/src/pages/Home/components/AboutUs.tsx
+++ b/src/pages/Home/components/AboutUs.tsx
@@ -68,9 +68,9 @@ export default function AboutUs() {
       </div>
       <div
         className='w-full h-[900px] flex-col-center gap-48 max-w-[678] text-center 
-        leading-[1.3] max-md:h-[1060px]'
+        leading-[1.3] max-md:h-[1020px]'
       >
-        <h2 className='text-center text-40 font-extrabold tracking-tight max-md:text-24'>
+        <h2 className='text-center text-40 font-extrabold tracking-tight max-md:text-24 max-md:mb-70'>
           고교학점제 시대, <br className='md:hidden' />
           중고등학생들을 위한 <br />
           데이터 사이언스 교육의 선두 주자!

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -3,8 +3,25 @@
  * @param localDateTimeString LocalDateTime 형식 string
  * @returns YYYY-MM-DD hh:mm
  */
+
+export const formatDate = (localDateTimeString: string, hasTime?: boolean) => {
+  const date = new Date(localDateTimeString);
+  const koreanTime = new Date(date.getTime() + 9 * 60 * 60 * 1000); // UTC+9 시간차(한국 시간) 적용
+
+  const year = koreanTime.getFullYear();
+  const month = String(koreanTime.getMonth() + 1).padStart(2, '0');
+  const day = String(koreanTime.getDate()).padStart(2, '0');
+  const hours = String(koreanTime.getHours()).padStart(2, '0');
+  const minutes = String(koreanTime.getMinutes()).padStart(2, '0');
+
+  const formattedTime = `${year}-${month}-${day} ${hasTime ? `${hours}:${minutes}` : ``}`;
+  return formattedTime;
+};
+
+/* // 서버에서 한국 시간으로 넘겨주면 사용할 코드
 export const formatDate = (localDateTimeString: string) => {
   const [date, timePart] = localDateTimeString.split('T');
   const time = timePart.slice(0, 5);
   return `${date} ${time}`;
 };
+*/


### PR DESCRIPTION
## 📝 개요

figma랑 살짝 안 맞는 부분이 있어서 수정했습니다!

**before / after**
![image](https://github.com/user-attachments/assets/8e9227ee-8699-45a2-b1e3-6f04f8077abf)

- 게시글, 댓글 작성일 한국 시간 적용 및 시간 추가

수정 전
![image](https://github.com/user-attachments/assets/fd681a05-fae5-4cf9-86a2-d42e0be766cb)

수정 후
![image](https://github.com/user-attachments/assets/af551cd8-93c0-4bca-ac95-bc4e879d0c53)

서버에서 UTC 시간을 넘겨주다보니 0시 ~ 9시 사이 작성한 게시글, 댓글의 작성 날짜가 하루 전으로 뜨는 문제가 있었습니다. 시간이 다른 건 안 보여주면 되지만 날짜가 바뀌는 건 무시하기 어려운 문제라고 생각해서 수정 님과 논의 후에 백엔드에서 한국 시간으로 변환 성공하기 전까지는 프론트에서 한국 시간으로 변환하도록 했습니다.

- 게시글 상세, 댓글에는 시간 추가

<img src='https://github.com/user-attachments/assets/ef673228-605e-452f-bc11-fdc9589ef5c6' width='500px'/>



## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#192

## ➕ 기타

크게 거슬리는 건 아니니 프로덕션 반영은 다른 거랑 같이 천천히 할게용
