### PR TITLE
fix: 클래스 파일 관련 문제 수정

### DIFF
--- a/src/pages/Classes/[classId]/[subClassId]/index.tsx
+++ b/src/pages/Classes/[classId]/[subClassId]/index.tsx
@@ -8,6 +8,7 @@ import useGetSubClassFileList from '@/hooks/class/useGetSubClassFileList';
 import useModal from '@/hooks/useModal';
 import ExamContent from '@/pages/Classes/components/ExamContent';
 import SubClassFileItem from '@/pages/Classes/components/SubClassFileItem';
+import useBoundStore from '@/stores';
 import { FileData } from '@/types/class';
 
 function SubClass() {
@@ -36,9 +37,25 @@ function SubClass() {
     [fileList],
   );
 
+  const { user } = useBoundStore();
+
   const [theoryFiles, setTheoryFiles] = useState<FileData[]>([]);
   const [dataFiles, setDataFiles] = useState<FileData[]>([]);
   const [examFiles, setExamFiles] = useState<FileData[]>([]);
+
+  const handleExamClick = () => {
+    if (user?.role !== '관리자' && user?.role !== '학생') {
+      setModalMessage('학생 이상만 이용 가능합니다.');
+      toggleModal();
+      return;
+    }
+    if (examFiles.length < 1) {
+      setModalMessage('시험 파일이 없습니다.');
+      toggleModal();
+      return;
+    }
+    setOpenExam(prev => !prev);
+  };
 
   useEffect(() => {
     if (fileList) {
@@ -78,10 +95,7 @@ function SubClass() {
         )}
 
         {examFiles.length > 0 && (
-          <button
-            className={buttonStyle}
-            onClick={() => setOpenExam(prev => !prev)}
-          >
+          <button className={buttonStyle} onClick={handleExamClick}>
             <div className={iconWrapperStyle}>
               <CheckToSlot className={iconStyle} />
             </div>

--- a/src/pages/Classes/[classId]/[subClassId]/index.tsx
+++ b/src/pages/Classes/[classId]/[subClassId]/index.tsx
@@ -1,15 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import Book from '@/assets/icons/book.svg?react';
 import CheckToSlot from '@/assets/icons/check-to-slot.svg?react';
-import Paperclip from '@/assets/icons/paperclip.svg?react';
 import { useSubClassIdMap } from '@/components/ClassLayout';
 import MessageModal from '@/components/MessageModal';
 import useGetSubClassFileList from '@/hooks/class/useGetSubClassFileList';
 import useModal from '@/hooks/useModal';
 import ExamContent from '@/pages/Classes/components/ExamContent';
-import useFileHandler from '@/pages/Classes/hooks/useFileHandler';
+import SubClassFileItem from '@/pages/Classes/components/SubClassFileItem';
+import { FileData } from '@/types/class';
 
 function SubClass() {
   const buttonStyle =
@@ -26,53 +25,32 @@ function SubClass() {
   const [modalMessage, setModalMessage] = useState('');
   const [openExam, setOpenExam] = useState(false);
 
-  const { handleDownloadFile, handleExamClick, generalFile } = useFileHandler({
-    subClassId: subClassIdMap[`${classId?.toUpperCase()}-${subClassId}`],
-    toggleModal,
-    setModalMessage,
-    setOpenExam,
-  });
-
   const { data: fileList } = useGetSubClassFileList({
     subLectureId: subClassIdMap[`${classId?.toUpperCase()}-${subClassId}`],
   });
 
-  const [fileState, setFileState] = useState<{
-    theory: boolean;
-    data: boolean;
-    exam: boolean;
-  }>({
-    theory: false,
-    data: false,
-    exam: false,
-  });
+  const findFiles = useCallback(
+    (type: string) => {
+      return fileList?.filter(file => file.assignmentType === type);
+    },
+    [fileList],
+  );
+
+  const [theoryFiles, setTheoryFiles] = useState<FileData[]>([]);
+  const [dataFiles, setDataFiles] = useState<FileData[]>([]);
+  const [examFiles, setExamFiles] = useState<FileData[]>([]);
 
   useEffect(() => {
     if (fileList) {
-      setFileState({ theory: false, data: false, exam: false });
-      fileList.forEach(file => {
-        const { assignmentType } = file;
-        if (assignmentType === '이론') {
-          setFileState(prev => ({
-            ...prev,
-            theory: true,
-          }));
-        }
-        if (assignmentType === '자료') {
-          setFileState(prev => ({
-            ...prev,
-            data: true,
-          }));
-        }
-        if (assignmentType === '시험') {
-          setFileState(prev => ({
-            ...prev,
-            exam: true,
-          }));
-        }
-      });
+      setTheoryFiles(findFiles('이론') ?? []);
+      setDataFiles(findFiles('자료') ?? []);
+      setExamFiles(findFiles('시험') ?? []);
     }
-  }, [fileList, classId, subClassId]);
+  }, [fileList, classId, subClassId, findFiles]);
+
+  useEffect(() => {
+    setOpenExam(false);
+  }, [classId, subClassId]);
 
   return (
     <>
@@ -81,32 +59,29 @@ function SubClass() {
           'mt-0 mb-60 px-50 grid grid-cols-2 sm:flex-row-center gap-20 sm:gap-50'
         }
       >
-        {fileState.theory && (
-          <button
-            className={buttonStyle}
-            onClick={() => handleDownloadFile('이론')}
-          >
-            <div className={iconWrapperStyle}>
-              <Book className={iconStyle} />
-            </div>
-            <div className={textStyle}>이론</div>
-          </button>
+        {theoryFiles.length > 0 && (
+          <SubClassFileItem
+            type={'이론'}
+            files={theoryFiles}
+            toggleModal={toggleModal}
+            setModalMessage={setModalMessage}
+          />
         )}
 
-        {fileState.data && (
-          <button
-            className={buttonStyle}
-            onClick={() => handleDownloadFile('자료')}
-          >
-            <div className={iconWrapperStyle}>
-              <Paperclip className={iconStyle} />
-            </div>
-            <div className={textStyle}>자료</div>
-          </button>
+        {dataFiles.length > 0 && (
+          <SubClassFileItem
+            type={'자료'}
+            files={dataFiles}
+            toggleModal={toggleModal}
+            setModalMessage={setModalMessage}
+          />
         )}
 
-        {fileState.exam && (
-          <button className={buttonStyle} onClick={handleExamClick}>
+        {examFiles.length > 0 && (
+          <button
+            className={buttonStyle}
+            onClick={() => setOpenExam(prev => !prev)}
+          >
             <div className={iconWrapperStyle}>
               <CheckToSlot className={iconStyle} />
             </div>
@@ -114,6 +89,9 @@ function SubClass() {
           </button>
         )}
       </div>
+      {examFiles.length > 0 && openExam && (
+        <ExamContent assignmentFileId={examFiles[0].assignmentFileId} />
+      )}
 
       <MessageModal
         isVisible={isVisible}
@@ -121,16 +99,6 @@ function SubClass() {
         type={'error'}
         message={modalMessage}
       />
-      {/* form exam */}
-      {/* {openExam && examInfo && <ExamForm examInfo={examInfo} />} */}
-
-      {/* pdf, hwp exam */}
-      {fileState.exam && openExam && (
-        <ExamContent
-          examFileUrl={generalFile?.filePresignedUrl}
-          studentFileId={generalFile?.assignmentAnswerFileId}
-        />
-      )}
     </>
   );
 }

--- a/src/pages/Classes/[classId]/[subClassId]/index.tsx
+++ b/src/pages/Classes/[classId]/[subClassId]/index.tsx
@@ -67,6 +67,9 @@ function SubClass() {
 
   useEffect(() => {
     setOpenExam(false);
+    setTheoryFiles([]);
+    setDataFiles([]);
+    setExamFiles([]);
   }, [classId, subClassId]);
 
   return (

--- a/src/pages/Classes/components/ExamContent.tsx
+++ b/src/pages/Classes/components/ExamContent.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback } from 'react';
 
 import useGetSubClassGeneralFile from '@/hooks/class/useGetSubClassGeneralFile';
 import useGetSubClassStudentFile from '@/hooks/class/useGetSubClassStudentFile';
 import useGetPdfUrl from '@/pages/Classes/hooks/useGetPdfUrl';
-import useBoundStore from '@/stores';
 import { getFileName } from '@/utils/getFileName';
 
 interface ExamContentProps {
@@ -14,8 +13,6 @@ function ExamContent({ assignmentFileId }: ExamContentProps) {
   const buttonStyle =
     'p-5 md:p-10 text-18 md:text-20 border-2 border-primary-300 rounded-lg hover:bg-primary-300 hover:text-white transition ease-in-out delay-50';
 
-  const [isPdf, setIsPdf] = useState(false);
-
   const { data: examFile } = useGetSubClassGeneralFile({
     assignmentFileId,
   });
@@ -25,50 +22,42 @@ function ExamContent({ assignmentFileId }: ExamContentProps) {
     enabled: !!examFile?.assignmentAnswerFileId,
   });
 
-  const { pdfUrl } = useGetPdfUrl({ s3Url: examFile?.filePresignedUrl });
+  const getFileExtension = useCallback((fileName: string | undefined) => {
+    return fileName?.split('.').pop();
+  }, []);
 
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const { pdfUrl } = useGetPdfUrl({
+    s3Url: examFile?.filePresignedUrl,
+    enabled:
+      examFile &&
+      getFileExtension(getFileName(examFile?.filePresignedUrl)) === 'pdf',
+  });
 
-  const { headerRef } = useBoundStore();
-  const handleIntersect = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          headerRef?.classList.add('hidden');
-        } else {
-          headerRef?.classList.remove('hidden');
-        }
-      });
-    },
-    [headerRef],
-  );
-
-  useEffect(() => {
-    if (iframeRef.current && headerRef) {
-      const observer = new IntersectionObserver(handleIntersect, {
-        root: null,
-        rootMargin: '0px',
-        threshold: 0.6,
-      });
-      observer.observe(iframeRef.current);
+  const handleFileOpen = () => {
+    const newWindow = window.open(pdfUrl, '_blank', 'noopener,noreferrer');
+    if (newWindow) {
+      newWindow.opener = null;
     }
-  }, [handleIntersect, headerRef]);
+  };
 
-  useEffect(() => {
-    if (
-      examFile?.filePresignedUrl &&
-      getFileName(examFile?.filePresignedUrl)?.split('.').pop() === 'pdf'
-    ) {
-      setIsPdf(true);
-    }
-  }, [examFile]);
+  if (!examFile) {
+    return null;
+  }
 
   return (
     <div className={'w-full pb-50 flex-col-center gap-30'}>
       <div className={'w-full flex-col-center sm:flex-row-center gap-30'}>
-        {!isPdf && (
+        {getFileExtension(getFileName(examFile?.filePresignedUrl)) === 'pdf' ? (
+          <button
+            type={'button'}
+            className={buttonStyle}
+            onClick={handleFileOpen}
+          >
+            새 탭에서 열기 ({getFileName(examFile?.filePresignedUrl)})
+          </button>
+        ) : (
           <a href={examFile?.filePresignedUrl} download className={buttonStyle}>
-            시험 파일 다운로드
+            파일 다운로드 ({getFileName(examFile?.filePresignedUrl)})
           </a>
         )}
 
@@ -78,25 +67,10 @@ function ExamContent({ assignmentFileId }: ExamContentProps) {
             download
             className={buttonStyle}
           >
-            제출용 파일 다운로드
+            파일 다운로드 ({getFileName(examStudentFile.filePresignedUrl)})
           </a>
         )}
       </div>
-
-      {isPdf && (
-        <div
-          className={
-            'min-w-[300px] w-[85%] h-[500px] sm:h-[700px] md:h-[900px]'
-          }
-        >
-          <iframe
-            ref={iframeRef}
-            src={pdfUrl}
-            title={'exam'}
-            className={'w-full h-full'}
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/Classes/components/SubClassFileItem.tsx
+++ b/src/pages/Classes/components/SubClassFileItem.tsx
@@ -87,7 +87,7 @@ function SubClassFileItem({
       <div
         className={'text-20 sm:text-22 md:text-25 font-semibold text-center'}
       >
-        이론
+        {type}
       </div>
     </button>
   );

--- a/src/pages/Classes/components/SubClassFileItem.tsx
+++ b/src/pages/Classes/components/SubClassFileItem.tsx
@@ -65,7 +65,7 @@ function SubClassFileItem({
 
     const newWindow =
       type === '이론'
-        ? window.open(pdfUrl, '', 'noopener,noreferrer')
+        ? window.open(pdfUrl, '_blank', 'noopener,noreferrer')
         : window.open(data?.filePresignedUrl, '_self', 'noopener,noreferrer');
 
     if (newWindow) {

--- a/src/pages/Classes/components/SubClassFileItem.tsx
+++ b/src/pages/Classes/components/SubClassFileItem.tsx
@@ -1,0 +1,96 @@
+import Book from '@/assets/icons/book.svg?react';
+import Paperclip from '@/assets/icons/paperclip.svg?react';
+import useGetSubClassGeneralFile from '@/hooks/class/useGetSubClassGeneralFile';
+import { ApiError } from '@/libs/errors';
+import useGetPdfUrl from '@/pages/Classes/hooks/useGetPdfUrl';
+import useBoundStore from '@/stores';
+import { FileData } from '@/types/class';
+
+interface SubClassFileItemProps {
+  type: '이론' | '자료';
+  files: FileData[];
+  toggleModal: () => void;
+  setModalMessage: (message: string) => void;
+}
+
+function SubClassFileItem({
+  type,
+  files,
+  toggleModal,
+  setModalMessage,
+}: SubClassFileItemProps) {
+  const iconStyle =
+    'w-80 h-80 sm:w-85 sm:h-85 md:w-90 md:h-90 text-primary-300';
+
+  const { data, isError, error } = useGetSubClassGeneralFile({
+    assignmentFileId: files[0].assignmentFileId,
+  });
+
+  const { user } = useBoundStore();
+
+  const { pdfUrl } = useGetPdfUrl({
+    s3Url: data?.filePresignedUrl,
+    enabled: type === '이론',
+  });
+
+  const handleClick = () => {
+    if (user?.role !== '관리자' && user?.role !== '학생') {
+      setModalMessage('학생 이상만 이용 가능합니다.');
+      toggleModal();
+      return;
+    }
+
+    if (type === '이론' && user?.role !== '관리자') {
+      setModalMessage('관리자만 이용 가능합니다.');
+      toggleModal();
+      return;
+    }
+
+    if (isError) {
+      if (error instanceof ApiError) {
+        setModalMessage(error.message);
+        toggleModal();
+        return;
+      }
+      setModalMessage(`${type} 파일을 불러오는 중 문제가 생겼습니다.`);
+      toggleModal();
+      return;
+    }
+
+    if (!data || !data?.filePresignedUrl) {
+      setModalMessage(`${type} 파일이 없습니다.`);
+      toggleModal();
+      return;
+    }
+
+    const newWindow =
+      type === '이론'
+        ? window.open(pdfUrl, '', 'noopener,noreferrer')
+        : window.open(data?.filePresignedUrl, '_self', 'noopener,noreferrer');
+
+    if (newWindow) {
+      newWindow.opener = null;
+    }
+  };
+
+  return (
+    <button
+      className={
+        'w-100 min-h-[140px] flex flex-col justify-start items-center place-self-center'
+      }
+      onClick={handleClick}
+    >
+      <div className={'w-100 h-100 flex-row-center'}>
+        {type === '이론' && <Book className={iconStyle} />}
+        {type === '자료' && <Paperclip className={iconStyle} />}
+      </div>
+      <div
+        className={'text-20 sm:text-22 md:text-25 font-semibold text-center'}
+      >
+        이론
+      </div>
+    </button>
+  );
+}
+
+export default SubClassFileItem;

--- a/src/pages/Classes/hooks/useGetPdfUrl.ts
+++ b/src/pages/Classes/hooks/useGetPdfUrl.ts
@@ -16,7 +16,9 @@ function useGetPdfUrl({
       if (!s3Url || !enabled) {
         return;
       }
-      const file = await convertURLtoFile(s3Url, 'pdf');
+      const file = await convertURLtoFile(s3Url, 'pdf', {
+        type: 'application/pdf',
+      });
       const fileUrl = URL.createObjectURL(file);
       setPdfUrl(fileUrl);
     } catch (error) {

--- a/src/pages/Classes/hooks/useGetPdfUrl.ts
+++ b/src/pages/Classes/hooks/useGetPdfUrl.ts
@@ -1,7 +1,13 @@
 import axios from 'axios';
 import { useCallback, useEffect, useState } from 'react';
 
-function useGetPdfUrl({ examFileUrl }: { examFileUrl: string | undefined }) {
+function useGetPdfUrl({
+  s3Url,
+  enabled = true,
+}: {
+  s3Url: string | undefined;
+  enabled?: boolean;
+}) {
   const [pdfUrl, setPdfUrl] = useState<string | undefined>(undefined);
 
   const convertURLtoPdfFile = async (url: string) => {
@@ -15,23 +21,23 @@ function useGetPdfUrl({ examFileUrl }: { examFileUrl: string | undefined }) {
 
   const getPdfUrl = useCallback(async () => {
     try {
-      if (!examFileUrl) {
+      if (!s3Url || !enabled) {
         return;
       }
-      const file = await convertURLtoPdfFile(examFileUrl);
+      const file = await convertURLtoPdfFile(s3Url);
       const fileUrl = URL.createObjectURL(file);
       setPdfUrl(fileUrl);
     } catch (error) {
       alert('시험 파일을 불러오는데 실패했습니다.');
       console.log('파일 변환 실패 : ', error);
     }
-  }, [examFileUrl]);
+  }, [s3Url]);
 
   useEffect(() => {
-    if (examFileUrl) {
+    if (s3Url) {
       getPdfUrl();
     }
-  }, [examFileUrl, getPdfUrl]);
+  }, [s3Url, getPdfUrl]);
 
   return { pdfUrl };
 }

--- a/src/pages/Classes/hooks/useGetPdfUrl.ts
+++ b/src/pages/Classes/hooks/useGetPdfUrl.ts
@@ -1,5 +1,6 @@
-import axios from 'axios';
 import { useCallback, useEffect, useState } from 'react';
+
+import { convertURLtoFile } from '@/utils/convertURLtoFile';
 
 function useGetPdfUrl({
   s3Url,
@@ -10,21 +11,12 @@ function useGetPdfUrl({
 }) {
   const [pdfUrl, setPdfUrl] = useState<string | undefined>(undefined);
 
-  const convertURLtoPdfFile = async (url: string) => {
-    const response = await axios.get(url, {
-      responseType: 'blob',
-      withCredentials: true,
-    });
-    const blob = response.data;
-    return new File([blob], 'exam-pdf', { type: 'application/pdf' });
-  };
-
   const getPdfUrl = useCallback(async () => {
     try {
       if (!s3Url || !enabled) {
         return;
       }
-      const file = await convertURLtoPdfFile(s3Url);
+      const file = await convertURLtoFile(s3Url, 'pdf');
       const fileUrl = URL.createObjectURL(file);
       setPdfUrl(fileUrl);
     } catch (error) {

--- a/src/pages/My/hooks/useProfileForm.ts
+++ b/src/pages/My/hooks/useProfileForm.ts
@@ -92,7 +92,10 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
 
   const getCurrentImageFile = async () => {
     if (compressedImageFile) return compressedImageFile;
-    if (imagePreview && user.imageUrl) return convertURLtoFile(user.imageUrl);
+    if (imagePreview && user.imageUrl)
+      return convertURLtoFile(user.imageUrl, 'profile-image', {
+        headers: { 'Cache-Control': 'no-cache' },
+      });
     return null;
   };
 

--- a/src/types/class.ts
+++ b/src/types/class.ts
@@ -13,3 +13,8 @@ export interface ClassData {
 }
 
 export type SubClassIdMap = { [key: string]: number };
+
+export type FileData = {
+  assignmentType: string;
+  assignmentFileId: number;
+};

--- a/src/utils/convertURLtoFile.ts
+++ b/src/utils/convertURLtoFile.ts
@@ -1,16 +1,18 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
-export const convertURLtoFile = async (url: string) => {
+export const convertURLtoFile = async (
+  url: string,
+  filename: string,
+  options?: { type?: string; headers?: AxiosRequestConfig['headers'] },
+) => {
   try {
     const response = await axios.get(url, {
       responseType: 'blob',
       withCredentials: true,
-      headers: {
-        'Cache-Control': 'no-cache',
-      },
+      headers: options?.headers || {},
     });
     const blob = response.data;
-    return new File([blob], 'profile-image', { type: blob.type });
+    return new File([blob], filename, { type: options?.type ?? blob.type });
   } catch (error) {
     console.log('파일 변환 실패 : ', error);
     throw error;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

- 모바일, 태블릿 환경에서 pdf 안보이는 문제
- 모바일, 태블릿 환경에서 클래스 바꿀때마다 다운로드 창 뜨는 문제

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 이론, 시험 pdf 파일은 새탭에서 여는 걸로 수정했습니다.
- 시험이 pdf가 아니면 다운로드 버튼 뜨게 해놨습니다.
- 기존에 모바일에서 클래스를 이동하면 이전 클래스의 다운로드 창이 계속 뜨던 문제가 있어서 파일 관련 상태들을 다 분리하고 컴포넌트도 따로 분리했습니다. 
  - 로컬에서 모바일이나 태블릿으로 노트북 ip로 접속하면 로그인이 안돼서 dev에 붙으면 바로 테스트하고 확인하겠습니다.

https://github.com/user-attachments/assets/06367500-caec-4f6e-87bb-14ca918dc8ad

- 시험 파일이 pdf 아닌 경우
<img width="1440" alt="스크린샷 2024-09-25 오후 4 52 43" src="https://github.com/user-attachments/assets/407c8968-544c-40a2-9fa0-fb63f6e0a6af">

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

#194

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
