### PR TITLE
refactor: 헤더 모바일 메뉴 사이드바로 변경

### DIFF
--- a/src/components/Footer/FooterNav.tsx
+++ b/src/components/Footer/FooterNav.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
 
-import { HeaderNavItem } from '@/types/navTypes';
+import { NavItem } from '@/types/navTypes';
 
-export const footerNavItems: HeaderNavItem[] = [
+export const footerNavItems: NavItem[] = [
   {
     type: 'link',
     to: '/',

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -16,7 +16,8 @@ interface MemberButtonsProps extends ButtonsProps {
   name: string;
 }
 
-const btnStyle = 'w-100 h-36 px-20 py-4 flex-row-center rounded-[20px] text-14';
+const btnStyle =
+  'w-120 xl:w-100 h-46 xl:h-36 px-20 py-4 flex-row-center rounded-[20px] text-18 xl:text-14';
 
 function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
   const { handleLogout } = useLogout();
@@ -28,18 +29,18 @@ function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
 
   return (
     <>
-      <Link className={'flex w-fit h-36 text-14 items-center'} to='/mypage'>
+      <Link className={'flex w-fit h-36 items-center'} to='/mypage'>
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-fit px-10 xl:px-14 h-36 flex-row-center text-14 font-semibold text-primary-400'
+            'w-fit px-10 xl:px-14 h-36 flex-row-center text-18 xl:text-14  font-semibold text-primary-400'
           }
         >
           {name}
         </div>
       </Link>
       <button
-        className={`${btnStyle} bg-primary-400 text-white`}
+        className={`${btnStyle} bg-primary-400 text-18 xl:text-14 w-fit text-white`}
         onClick={handleClick}
       >
         로그아웃
@@ -69,13 +70,13 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
   return (
     <>
       <button
-        className={'hidden xl:flex w-100 h-36 text-14 items-center gap-4'}
+        className={'hidden xl:flex w-100 h-36 items-center gap-4'}
         onClick={() => handleClick('login')}
       >
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-64 h-36 flex-row-center text-14 font-semibold text-primary-400'
+            'w-64 h-36 flex-row-center text-18 xl:text-14 font-semibold text-primary-400'
           }
         >
           로그인
@@ -88,7 +89,7 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
         로그인
       </button>
       <button
-        className={`${btnStyle} bg-primary-400 text-white`}
+        className={`${btnStyle} bg-primary-400 text-white w-full`}
         onClick={() => handleClick('register')}
       >
         회원가입

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -32,7 +32,7 @@ function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-fit px-10 md:px-14 h-36 flex-row-center text-14 font-semibold text-primary-400'
+            'w-fit px-10 xl:px-14 h-36 flex-row-center text-14 font-semibold text-primary-400'
           }
         >
           {name}
@@ -69,7 +69,7 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
   return (
     <>
       <button
-        className={'hidden md:flex w-100 h-36 text-14 items-center gap-4'}
+        className={'hidden xl:flex w-100 h-36 text-14 items-center gap-4'}
         onClick={() => handleClick('login')}
       >
         <UserLogin className={'w-30 h-30'} />
@@ -82,7 +82,7 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
         </div>
       </button>
       <button
-        className={`block md:hidden ${btnStyle} btn-white-pb`}
+        className={`block xl:hidden ${btnStyle} btn-white-pb`}
         onClick={() => handleClick('login')}
       >
         로그인
@@ -107,7 +107,7 @@ function HeaderButtons({ toggleMenu }: ButtonsProps) {
   const user = useBoundStore(state => state.user);
 
   return (
-    <div className={'flex flex-col items-center md:flex-row gap-10'}>
+    <div className={'flex flex-col items-center xl:flex-row gap-10'}>
       {user ? (
         <MemberButtons name={user.name} toggleMenu={toggleMenu} />
       ) : (

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -8,23 +8,20 @@ import useModal from '@/hooks/useModal';
 import useBoundStore from '@/stores';
 import { AuthModalType } from '@/types/auth';
 
-interface ButtonsProps {
-  toggleMenu?: () => void;
-}
-
-interface MemberButtonsProps extends ButtonsProps {
+interface MemberButtonsProps {
   name: string;
 }
 
 const btnStyle =
   'w-120 xl:w-100 h-46 xl:h-36 px-20 py-4 flex-row-center rounded-[20px] text-18 xl:text-14';
 
-function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
+function MemberButtons({ name }: MemberButtonsProps) {
   const { handleLogout } = useLogout();
+  const setIsSidebarOpen = useBoundStore(state => state.setIsSidebarOpen);
 
   const handleClick = () => {
     handleLogout();
-    if (toggleMenu) toggleMenu();
+    setIsSidebarOpen(false);
   };
 
   return (
@@ -49,9 +46,10 @@ function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
   );
 }
 
-function GuestButtons({ toggleMenu }: ButtonsProps) {
+function GuestButtons() {
   const { isVisible, toggleModal } = useModal();
   const [modalType, setModalType] = useState<AuthModalType>('login');
+  const setIsSidebarOpen = useBoundStore(state => state.setIsSidebarOpen);
 
   const handleClick = (type: AuthModalType) => {
     toggleModal();
@@ -60,7 +58,7 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
 
   const handleClose = () => {
     toggleModal();
-    if (toggleMenu) toggleMenu();
+    setIsSidebarOpen(false);
   };
 
   const toggleModalType = () => {
@@ -104,16 +102,12 @@ function GuestButtons({ toggleMenu }: ButtonsProps) {
   );
 }
 
-function HeaderButtons({ toggleMenu }: ButtonsProps) {
+function HeaderButtons() {
   const user = useBoundStore(state => state.user);
 
   return (
     <div className={'flex flex-col items-center xl:flex-row gap-10'}>
-      {user ? (
-        <MemberButtons name={user.name} toggleMenu={toggleMenu} />
-      ) : (
-        <GuestButtons toggleMenu={toggleMenu} />
-      )}
+      {user ? <MemberButtons name={user.name} /> : <GuestButtons />}
     </div>
   );
 }

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -33,14 +33,14 @@ function MemberButtons({ name, toggleMenu }: MemberButtonsProps) {
         <UserLogin className={'w-30 h-30'} />
         <div
           className={
-            'w-fit px-10 xl:px-14 h-36 flex-row-center text-18 xl:text-14  font-semibold text-primary-400'
+            'w-fit h-46 xl:h-36 px-20 xl:px-14 py-4 xl:py-0 flex-row-center text-18 xl:text-14 font-semibold text-primary-400'
           }
         >
           {name}
         </div>
       </Link>
       <button
-        className={`${btnStyle} bg-primary-400 text-18 xl:text-14 w-fit text-white`}
+        className={`${btnStyle} bg-primary-400 text-18 xl:text-14 text-white`}
         onClick={handleClick}
       >
         로그아웃

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -3,7 +3,7 @@ import HeaderNav from './HeaderNav';
 
 function HeaderMenu() {
   return (
-    <div className={'hidden md:flex justify-between items-end'}>
+    <div className={'hidden xl:flex justify-between items-end'}>
       <HeaderNav />
       <HeaderButtons />
     </div>

--- a/src/components/Header/HeaderNav.tsx
+++ b/src/components/Header/HeaderNav.tsx
@@ -15,7 +15,7 @@ function HeaderNav() {
   const user = useBoundStore(state => state.user);
 
   return (
-    <div className={'flex items-center gap-30 lg:gap-40'}>
+    <div className={'flex items-center gap-40'}>
       {headerNavItems.map((item: HeaderNavItem) => {
         if (item.type === 'link') {
           return (

--- a/src/components/Header/HeaderNav.tsx
+++ b/src/components/Header/HeaderNav.tsx
@@ -3,7 +3,6 @@ import { NavLink } from 'react-router-dom';
 import Dropdown from '@/components/Dropdown';
 import { adminNavItem, headerNavItems } from '@/constants/navItems';
 import useBoundStore from '@/stores';
-import { HeaderNavItem } from '@/types/navTypes';
 
 function HeaderNav() {
   const linkStyle = 'text-13 font-bold';
@@ -16,7 +15,7 @@ function HeaderNav() {
 
   return (
     <div className={'flex items-center gap-40'}>
-      {headerNavItems.map((item: HeaderNavItem) => {
+      {headerNavItems.map(item => {
         if (item.type === 'link') {
           return (
             <NavLink

--- a/src/components/Header/MenuToggle.tsx
+++ b/src/components/Header/MenuToggle.tsx
@@ -1,0 +1,47 @@
+function Path(props: {
+  d: string;
+  className: string;
+  variants?: { [key: string]: { d: string } };
+  opacity?: string;
+}) {
+  return (
+    <path
+      fill='transparent'
+      strokeWidth='3'
+      stroke='#000090'
+      strokeLinecap='round'
+      {...props}
+    />
+  );
+}
+
+function MenuToggle({ toggle }: { toggle: () => void }) {
+  return (
+    <button
+      onClick={toggle}
+      className='bg-transparent relative z-[102] outline-none border-none select-none cursor-pointer px-10 flex-col-center rounded-full'
+    >
+      <svg width='23' height='18' viewBox='0 0 23 18' className={'relative'}>
+        <Path
+          d='M 2 2.5 L 20 2.5'
+          className={'top'}
+          variants={{
+            closed: { d: 'M 2 2.5 L 20 2.5' },
+            open: { d: 'M 3 16.5 L 17 2.5' },
+          }}
+        />
+        <Path d='M 2 9.423 L 20 9.423' opacity='1' className={'middle'} />
+        <Path
+          d='M 2 16.346 L 20 16.346'
+          className={'bottom'}
+          variants={{
+            closed: { d: 'M 2 16.346 L 20 16.346' },
+            open: { d: 'M 3 2.5 L 17 16.346' },
+          }}
+        />
+      </svg>
+    </button>
+  );
+}
+
+export default MenuToggle;

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -9,7 +9,8 @@ import useBoundStore from '@/stores';
 
 function MobileMenu() {
   const { pathname } = useLocation();
-  const { isSidebarOpen, setIsSidebarOpen } = useBoundStore();
+  const isSidebarOpen = useBoundStore(state => state.isSidebarOpen);
+  const setIsSidebarOpen = useBoundStore(state => state.setIsSidebarOpen);
 
   const scope = useMenuAnimation(isSidebarOpen);
 

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -1,35 +1,20 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
-import MenuIcon from '@/assets/icons/menu.svg?react';
-
-import MobileNav from './MobileNav';
+import Backdrop from '@/components/Backdrop';
+import MenuToggle from '@/components/Header/MenuToggle';
+import MobileSidebar from '@/components/Header/MobileSidebar';
+import useMenuAnimation from '@/hooks/useMenuAnimation';
 
 function MobileMenu() {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const toggleMenu = () => setIsMenuOpen(prev => !prev);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsMenuOpen(false);
-      }
-    }
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
+  const scope = useMenuAnimation(isOpen);
 
   return (
-    <div className={'md:hidden flex flex-end'} ref={menuRef}>
-      <div>
-        <div className={'grid place-items-center'}>
-          <MenuIcon className={'w-32 h-32'} onClick={toggleMenu} />
-        </div>
-        {isMenuOpen && <MobileNav onClick={toggleMenu} />}
-      </div>
+    <div ref={scope} className={'xl:hidden flex flex-end relative'}>
+      {isOpen && <Backdrop onClick={() => setIsOpen(false)} />}
+      <MobileSidebar />
+      <MenuToggle toggle={() => setIsOpen(prev => !prev)} />
     </div>
   );
 }

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import Backdrop from '@/components/Backdrop';
 import MenuToggle from '@/components/Header/MenuToggle';
@@ -6,13 +7,18 @@ import MobileSidebar from '@/components/Header/MobileSidebar';
 import useMenuAnimation from '@/hooks/useMenuAnimation';
 
 function MobileMenu() {
-  const [isOpen, setIsOpen] = useState(false);
+  const { pathname } = useLocation();
 
+  const [isOpen, setIsOpen] = useState(false);
   const scope = useMenuAnimation(isOpen);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
 
   return (
     <div ref={scope} className={'xl:hidden flex flex-end relative'}>
-      {isOpen && <Backdrop onClick={() => setIsOpen(false)} />}
+      {isOpen && <Backdrop onClick={() => setIsOpen(prev => !prev)} />}
       <MobileSidebar />
       <MenuToggle toggle={() => setIsOpen(prev => !prev)} />
     </div>

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -1,26 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import Backdrop from '@/components/Backdrop';
 import MenuToggle from '@/components/Header/MenuToggle';
 import MobileSidebar from '@/components/Header/MobileSidebar';
 import useMenuAnimation from '@/hooks/useMenuAnimation';
+import useBoundStore from '@/stores';
 
 function MobileMenu() {
   const { pathname } = useLocation();
+  const { isSidebarOpen, setIsSidebarOpen } = useBoundStore();
 
-  const [isOpen, setIsOpen] = useState(false);
-  const scope = useMenuAnimation(isOpen);
+  const scope = useMenuAnimation(isSidebarOpen);
 
   useEffect(() => {
-    setIsOpen(false);
+    setIsSidebarOpen(false);
   }, [pathname]);
 
   return (
     <div ref={scope} className={'xl:hidden flex flex-end relative'}>
-      {isOpen && <Backdrop onClick={() => setIsOpen(prev => !prev)} />}
+      {isSidebarOpen && <Backdrop onClick={() => setIsSidebarOpen(false)} />}
       <MobileSidebar />
-      <MenuToggle toggle={() => setIsOpen(prev => !prev)} />
+      <MenuToggle toggle={() => setIsSidebarOpen(prev => !prev)} />
     </div>
   );
 }

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -1,8 +1,9 @@
 import { CaretDown } from '@phosphor-icons/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
+import useBoundStore from '@/stores';
 import { NavItem } from '@/types/navTypes';
 
 const listVariants = {
@@ -21,16 +22,19 @@ interface MobileNavProps {
 }
 
 function MobileNav({ item }: MobileNavProps) {
-  const { pathname } = useLocation();
   const [listOpen, setListOpen] = useState(false);
 
   const navLinkStyle = (isActive: boolean) => {
     return isActive ? `text-primary-400 font-medium` : `text-neutral-400`;
   };
 
+  const { isSidebarOpen } = useBoundStore();
+
   useEffect(() => {
-    setListOpen(false);
-  }, [pathname]);
+    if (!isSidebarOpen) {
+      setListOpen(false);
+    }
+  }, [isSidebarOpen]);
 
   return (
     <div className={'w-full h-fit text-20'}>

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -1,47 +1,91 @@
-import { Link, NavLink } from 'react-router-dom';
+import { CaretDown } from '@phosphor-icons/react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import { NavLink } from 'react-router-dom';
 
-import { adminNavItem, mobileMenuNavItems } from '@/constants/navItems';
-import useBoundStore from '@/stores';
-import { MobileMenuNavItem } from '@/types/navTypes';
-
-import HeaderButtons from './HeaderButtons';
+const listVariants = {
+  open: {
+    opacity: 1,
+    height: 'fit-content',
+  },
+  closed: {
+    opacity: 0,
+    height: 0,
+  },
+};
 
 interface MobileNavProps {
-  onClick: () => void;
+  item: {
+    to: string;
+    text: string;
+    list?: { to: string; text: string }[];
+  };
 }
 
-function MobileNav({ onClick }: MobileNavProps) {
-  const user = useBoundStore(state => state.user);
+function MobileNav({ item }: MobileNavProps) {
+  const [listOpen, setListOpen] = useState(false);
+
+  const navLinkStyle = (isActive: boolean) => {
+    return isActive ? `text-primary-400 font-medium` : `text-neutral-400`;
+  };
+
+  useEffect(() => {
+    setListOpen(false);
+  }, []);
 
   return (
-    <div className={'absolute right-16 rounded-md bg-white'}>
-      <li className={`flex flex-col gap-8 px-16 py-8 my-12 bg-white`}>
-        {mobileMenuNavItems.map((item: MobileMenuNavItem) => {
-          return (
-            <Link
-              key={item.to}
-              to={item.to}
-              className={
-                'min-w-200 min-h-32 grid place-items-center text-15 px-12 hover:bg-primary-50'
-              }
-              onClick={onClick}
-            >
-              {item.text}
-            </Link>
-          );
-        })}
-        {user && user.role === '관리자' && (
-          <NavLink
-            to={adminNavItem.to}
-            className={
-              'min-w-200 min-h-32 grid place-items-center text-15 px-12 hover:bg-primary-50'
-            }
-          >
-            {adminNavItem.text}
-          </NavLink>
+    <div className={'w-full h-fit'}>
+      <div className={'w-full p-5 flex justify-between'}>
+        <NavLink
+          to={item.to}
+          key={item.to}
+          className={({ isActive }) => navLinkStyle(isActive)}
+        >
+          {item.text}
+        </NavLink>
+        <AnimatePresence>
+          {item.list && (
+            <button onClick={() => setListOpen(prev => !prev)}>
+              <motion.div
+                variants={{
+                  open: { rotate: 180 },
+                  closed: { rotate: 0 },
+                }}
+                transition={{ duration: 0.4 }}
+                animate={listOpen ? 'open' : 'closed'}
+              >
+                <CaretDown />
+              </motion.div>
+            </button>
+          )}
+        </AnimatePresence>
+      </div>
+
+      <AnimatePresence>
+        {item.list && (
+          <ul className={`flex flex-col`}>
+            {item.list?.map(listItem => (
+              <motion.li
+                key={listItem.to}
+                initial={'closed'}
+                variants={listVariants}
+                animate={listOpen ? 'open' : 'closed'}
+                transition={{ duration: 0.8, ease: [0.01, 0.52, 0.4, 0.98] }}
+                className={'flex'}
+              >
+                <NavLink
+                  to={listItem.to}
+                  className={({ isActive }) =>
+                    `${navLinkStyle(isActive)} px-20 pb-5 font-light`
+                  }
+                >
+                  {listItem.text}
+                </NavLink>
+              </motion.li>
+            ))}
+          </ul>
         )}
-        <HeaderButtons toggleMenu={onClick} />
-      </li>
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 
-import { HeaderNavItem } from '@/types/navTypes';
+import { NavItem } from '@/types/navTypes';
 
 const listVariants = {
   open: {
@@ -17,7 +17,7 @@ const listVariants = {
 };
 
 interface MobileNavProps {
-  item: HeaderNavItem;
+  item: NavItem;
 }
 
 function MobileNav({ item }: MobileNavProps) {

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -65,7 +65,7 @@ function MobileNav({ item }: MobileNavProps) {
       </div>
 
       <AnimatePresence>
-        {item.list && (
+        {item.list && listOpen && (
           <ul className={`flex flex-col`}>
             {item.list?.map(listItem => (
               <motion.li
@@ -73,6 +73,7 @@ function MobileNav({ item }: MobileNavProps) {
                 initial={'closed'}
                 variants={listVariants}
                 animate={listOpen ? 'open' : 'closed'}
+                exit={'closed'}
                 transition={{ duration: 0.8, ease: [0.01, 0.52, 0.4, 0.98] }}
                 className={'flex'}
               >

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -1,7 +1,9 @@
 import { CaretDown } from '@phosphor-icons/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
+
+import { HeaderNavItem } from '@/types/navTypes';
 
 const listVariants = {
   open: {
@@ -15,14 +17,11 @@ const listVariants = {
 };
 
 interface MobileNavProps {
-  item: {
-    to: string;
-    text: string;
-    list?: { to: string; text: string }[];
-  };
+  item: HeaderNavItem;
 }
 
 function MobileNav({ item }: MobileNavProps) {
+  const { pathname } = useLocation();
   const [listOpen, setListOpen] = useState(false);
 
   const navLinkStyle = (isActive: boolean) => {
@@ -31,7 +30,7 @@ function MobileNav({ item }: MobileNavProps) {
 
   useEffect(() => {
     setListOpen(false);
-  }, []);
+  }, [pathname]);
 
   return (
     <div className={'w-full h-fit'}>

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -33,7 +33,7 @@ function MobileNav({ item }: MobileNavProps) {
   }, [pathname]);
 
   return (
-    <div className={'w-full h-fit'}>
+    <div className={'w-full h-fit text-20'}>
       <div className={'w-full p-5 flex justify-between'}>
         <NavLink
           to={item.to}
@@ -53,7 +53,7 @@ function MobileNav({ item }: MobileNavProps) {
                 transition={{ duration: 0.4 }}
                 animate={listOpen ? 'open' : 'closed'}
               >
-                <CaretDown />
+                <CaretDown className={'w-25 h-25'} />
               </motion.div>
             </button>
           )}

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -28,7 +28,7 @@ function MobileNav({ item }: MobileNavProps) {
     return isActive ? `text-primary-400 font-medium` : `text-neutral-400`;
   };
 
-  const { isSidebarOpen } = useBoundStore();
+  const isSidebarOpen = useBoundStore(state => state.isSidebarOpen);
 
   useEffect(() => {
     if (!isSidebarOpen) {

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -5,6 +5,7 @@ import useBoundStore from '@/stores';
 
 function MobileSidebar() {
   const { user } = useBoundStore();
+  const { setIsSidebarOpen } = useBoundStore();
 
   return (
     <div
@@ -28,7 +29,7 @@ function MobileSidebar() {
       </nav>
       <div className={'w-1/2 h-1 bg-neutral-100 mb-10'}></div>
       <div className={'h-[15%] flex-row-center'}>
-        <HeaderButtons />
+        <HeaderButtons toggleMenu={() => setIsSidebarOpen(false)} />
       </div>
     </div>
   );

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -10,9 +10,10 @@ function MobileSidebar() {
     <div
       id={'mobile-sidebar'}
       className={
-        'absolute w-[200px] h-dvh top-[-25.76px] right-[-220px] pt-60 pb-30 flex flex-col gap-20 bg-white z-modal'
+        'absolute w-[200px] h-dvh top-[-25.76px] right-[-220px] pt-60 pb-30 flex flex-col-center bg-white z-modal'
       }
     >
+      <div className={'w-1/2 h-1 bg-neutral-100 mt-10'}></div>
       <nav className={'w-full h-[80%] relative overflow-hidden'}>
         <ul
           className={
@@ -25,7 +26,10 @@ function MobileSidebar() {
           {user?.role === '관리자' && <MobileNav item={adminNavItem} />}
         </ul>
       </nav>
-      <HeaderButtons />
+      <div className={'w-1/2 h-1 bg-neutral-100 mb-10'}></div>
+      <div className={'h-[15%] flex-row-center'}>
+        <HeaderButtons />
+      </div>
     </div>
   );
 }

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -10,7 +10,7 @@ function MobileSidebar() {
     <div
       id={'mobile-sidebar'}
       className={
-        'absolute w-[200px] h-dvh top-[-25.76px] right-[-220px] pt-60 pb-30 flex flex-col-center bg-white z-modal'
+        'absolute w-[300px] h-dvh top-[-25.76px] right-[-320px] pt-60 pb-30 flex flex-col-center bg-white z-modal'
       }
     >
       <div className={'w-1/2 h-1 bg-neutral-100 mt-10'}></div>

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -1,0 +1,33 @@
+import HeaderButtons from '@/components/Header/HeaderButtons';
+import MobileNav from '@/components/Header/MobileNav';
+import { adminNavItem, headerNavItems } from '@/constants/navItems';
+import useBoundStore from '@/stores';
+
+function MobileSidebar() {
+  const { user } = useBoundStore();
+
+  return (
+    <div
+      id={'mobile-sidebar'}
+      className={
+        'absolute w-[200px] h-dvh top-[-25.76px] right-[-220px] pt-60 pb-30 flex flex-col gap-20 bg-white z-modal'
+      }
+    >
+      <nav className={'w-full h-[85%] relative overflow-hidden'}>
+        <ul
+          className={
+            'relative w-full h-full px-30 py-20 flex flex-col gap-8 overflow-scroll'
+          }
+        >
+          {headerNavItems.map(item => (
+            <MobileNav item={item} key={item.to} />
+          ))}
+          {user?.role === '관리자' && <MobileNav item={adminNavItem} />}
+        </ul>
+      </nav>
+      <HeaderButtons />
+    </div>
+  );
+}
+
+export default MobileSidebar;

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -5,7 +5,6 @@ import useBoundStore from '@/stores';
 
 function MobileSidebar() {
   const { user } = useBoundStore();
-  const { setIsSidebarOpen } = useBoundStore();
 
   return (
     <div
@@ -29,7 +28,7 @@ function MobileSidebar() {
       </nav>
       <div className={'w-1/2 h-1 bg-neutral-100 mb-10'}></div>
       <div className={'h-[15%] flex-row-center'}>
-        <HeaderButtons toggleMenu={() => setIsSidebarOpen(false)} />
+        <HeaderButtons />
       </div>
     </div>
   );

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -13,7 +13,7 @@ function MobileSidebar() {
         'absolute w-[200px] h-dvh top-[-25.76px] right-[-220px] pt-60 pb-30 flex flex-col gap-20 bg-white z-modal'
       }
     >
-      <nav className={'w-full h-[85%] relative overflow-hidden'}>
+      <nav className={'w-full h-[80%] relative overflow-hidden'}>
         <ul
           className={
             'relative w-full h-full px-30 py-20 flex flex-col gap-8 overflow-scroll'

--- a/src/components/Header/MobileSidebar.tsx
+++ b/src/components/Header/MobileSidebar.tsx
@@ -4,7 +4,7 @@ import { adminNavItem, headerNavItems } from '@/constants/navItems';
 import useBoundStore from '@/stores';
 
 function MobileSidebar() {
-  const { user } = useBoundStore();
+  const user = useBoundStore(state => state.user);
 
   return (
     <div

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -20,7 +20,7 @@ function Header() {
   return (
     <header
       className={
-        'top-0 fixed w-full h-70 md:h-100 pl-26 pr-17 md:px-43 lg:px-103 py-17 md:pt-22 md:pb-10 flex justify-between items-center md:flex-col md:items-stretch bg-white z-10'
+        'top-0 fixed w-full h-70 xl:h-100 pl-35 pr-20 xl:px-103 py-17 xl:pt-22 xl:pb-10 flex justify-between items-center xl:flex-col xl:items-stretch bg-white z-10'
       }
       ref={headerRef}
     >

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ import MobileMenu from './MobileMenu';
 
 function Header() {
   const headerRef = useRef<HTMLElement | null>(null);
-  const { setHeaderRef } = useBoundStore();
+  const setHeaderRef = useBoundStore(state => state.setHeaderRef);
 
   useEffect(() => {
     if (headerRef.current) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,7 +14,7 @@ function Layout() {
   return (
     <>
       <Header />
-      <section className={'relative top-[70px] md:top-[100px]'}>
+      <section className={'relative top-[70px] xl:top-[100px]'}>
         <Suspense fallback={<div className='w-full h-[100dvh]'></div>}>
           <Outlet />
         </Suspense>

--- a/src/constants/navItems.ts
+++ b/src/constants/navItems.ts
@@ -1,6 +1,6 @@
-import { MobileMenuNavItem, HeaderNavItem } from '@/types/navTypes';
+import { NavItem } from '@/types/navTypes';
 
-export const headerNavItems: HeaderNavItem[] = [
+export const headerNavItems: NavItem[] = [
   {
     type: 'link',
     to: '/',
@@ -88,38 +88,7 @@ export const headerNavItems: HeaderNavItem[] = [
   },
 ];
 
-export const mobileMenuNavItems: MobileMenuNavItem[] = [
-  {
-    to: '/',
-    text: '홈',
-  },
-  {
-    to: '/about_us',
-    text: '회사소개',
-  },
-  {
-    to: '/classes',
-    text: '클래스',
-  },
-  {
-    to: '/community',
-    text: '커뮤니티',
-  },
-  {
-    to: '/homework',
-    text: '과제',
-  },
-  {
-    to: '/survey',
-    text: '설문',
-  },
-  {
-    to: '/contact',
-    text: '문의',
-  },
-];
-
-export const adminNavItem: MobileMenuNavItem = {
+export const adminNavItem: NavItem = {
   to: '/admin',
   text: '관리자',
 };

--- a/src/constants/navItems.ts
+++ b/src/constants/navItems.ts
@@ -32,19 +32,19 @@ export const headerNavItems: NavItem[] = [
     list: [
       {
         to: '/classes/a',
-        text: 'A-Class',
+        text: 'Class A',
       },
       {
         to: '/classes/b',
-        text: 'B-Class',
+        text: 'Class B',
       },
       {
         to: '/classes/c',
-        text: 'C-Class',
+        text: 'Class C',
       },
       {
         to: '/classes/d',
-        text: 'D-Class',
+        text: 'Class D',
       },
     ],
   },

--- a/src/hooks/useMenuAnimation.ts
+++ b/src/hooks/useMenuAnimation.ts
@@ -1,0 +1,37 @@
+import { AnimationSequence, useAnimate } from 'framer-motion';
+import { useEffect } from 'react';
+
+function useMenuAnimation(isOpen: boolean) {
+  const [scope, animate] = useAnimate();
+
+  useEffect(() => {
+    const menuAnimations: AnimationSequence = isOpen
+      ? [
+          [
+            '#mobile-sidebar',
+            { transform: 'translateX(-100%)' },
+            { ease: [0.08, 0.65, 0.53, 0.96], duration: 0.3 },
+          ],
+        ]
+      : [['#mobile-sidebar', { transform: 'translateX(0%)' }, { at: '-0.1' }]];
+
+    animate([
+      [
+        'path.top',
+        { d: isOpen ? 'M 3 16.5 L 17 2.5' : 'M 2 2.5 L 20 2.5' },
+        { at: '<' },
+      ],
+      ['path.middle', { opacity: isOpen ? 0 : 1 }, { at: '<' }],
+      [
+        'path.bottom',
+        { d: isOpen ? 'M 3 2.5 L 17 16.346' : 'M 2 16.346 L 20 16.346' },
+        { at: '<' },
+      ],
+      ...menuAnimations,
+    ]);
+  }, [isOpen]);
+
+  return scope;
+}
+
+export default useMenuAnimation;

--- a/src/stores/headerSlice.ts
+++ b/src/stores/headerSlice.ts
@@ -2,19 +2,37 @@ import { StateCreator } from 'zustand';
 
 type State = {
   headerRef: HTMLElement | null;
+  isSidebarOpen: boolean;
 };
 
 type Actions = {
   setHeaderRef: (headerRef: HTMLElement | null) => void;
+  setIsSidebarOpen: (
+    nextState:
+      | State['isSidebarOpen']
+      | ((current: State['isSidebarOpen']) => State['isSidebarOpen']),
+  ) => void;
 };
 
 export type HeaderSlice = State & Actions;
 
 const initialState: State = {
   headerRef: null,
+  isSidebarOpen: false,
 };
 
 export const createHeaderSlice: StateCreator<HeaderSlice> = set => ({
   ...initialState,
-  setHeaderRef: headerRef => set({ headerRef }),
+  setHeaderRef: headerRef =>
+    set({
+      headerRef,
+    }),
+  setIsSidebarOpen: nextState => {
+    set(state => ({
+      isSidebarOpen:
+        typeof nextState === 'function'
+          ? nextState(state.isSidebarOpen)
+          : nextState,
+    }));
+  },
 });

--- a/src/types/navTypes.ts
+++ b/src/types/navTypes.ts
@@ -4,7 +4,7 @@ export interface MobileMenuNavItem {
 }
 
 export interface HeaderNavItem extends MobileMenuNavItem {
-  type: 'link' | 'dropdown';
+  type?: 'link' | 'dropdown';
   list?: {
     to: string;
     text: string;

--- a/src/types/navTypes.ts
+++ b/src/types/navTypes.ts
@@ -1,9 +1,6 @@
-export interface MobileMenuNavItem {
+export interface NavItem {
   to: string;
   text: string;
-}
-
-export interface HeaderNavItem extends MobileMenuNavItem {
   type?: 'link' | 'dropdown';
   list?: {
     to: string;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

헤더 모바일 메뉴 사이드바로 변경

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 헤더 모바일 메뉴 사이드바로 변경했습니다.
- 모바일 메뉴바가 뜨는 중단점이 변경됐습니다.(md -> xl) 1280px 까지 모바일 메뉴로 설정했습니다.
- 페이지 이동없이 사이드바 열고 닫고 했을 때는 하위 경로들 보여주는 drawer 상태는 그대로 남습니다.
  - url 변경 시에만 drawer 상태 초기화하게 했습니다.
- 기존 props 넘겨서 외부 클릭하면 닫는 방식에서 backdrop으로 변경했습니다.


## 피드백 수정
- 사이드바 상태를 전역변수로 관리합니다.
- 글자 크기와 사이드바 너비 키웠습니다.
- 로그인, 로그아웃, 회원가입 시 사이드바 닫히게 toggleMenu 값 넘겨줬습니다.

https://github.com/user-attachments/assets/3a2ef8b8-72bb-4b11-ac40-d5e8a35c370b


https://github.com/user-attachments/assets/129e19e0-8651-4b08-8fec-bc17e10519b3


https://github.com/user-attachments/assets/17b71db1-9e0d-41ef-b585-a6047da7fa13




## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

#200 

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->


