### PR TITLE
refactor: 액세스 토큰 관리 방식 수정

### DIFF
--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useForm, FieldValues } from 'react-hook-form';
 
+import { setAccessToken } from '@/libs/api';
 import { ApiError } from '@/libs/errors';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
@@ -45,7 +46,8 @@ export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
   const loginMutation = useMutation({
     mutationFn: ({ email, password }: ILoginFormInput) =>
       auth.login(email, password),
-    onSuccess: () => {
+    onSuccess: data => {
+      setAccessToken(data.accessToken);
       setIsAutoLogin();
       onSuccess();
     },

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import { removeAccessToken } from '@/libs/api';
 import { clearSelectedQueries } from '@/libs/react-query';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
@@ -14,11 +15,12 @@ export default function useLogout() {
 
   const handleLogout = async () => {
     try {
-      await auth.logout();
-      navigate('/');
       resetAuthState();
       resetUser();
+      await auth.logout();
+      removeAccessToken();
       clearSelectedQueries(['user', 'homework', 'survey']);
+      navigate('/');
     } catch (error) {
       console.log('error with logout: ', error);
     }

--- a/src/hooks/homework/useGetHomework.ts
+++ b/src/hooks/homework/useGetHomework.ts
@@ -1,30 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 
 import { ApiError } from '@/libs/errors';
 import HomeworkApi from '@/services/homework';
-import useBoundStore from '@/stores';
 
 interface UseGetHomeworkProps {
   homeworkId: number;
 }
 
 function useGetHomework({ homeworkId }: UseGetHomeworkProps) {
-  const [queryEnabled, setQueryEnabled] = useState(false);
-  const user = useBoundStore(state => state.user);
-  const accessToken = useBoundStore(state => state.accessToken);
-
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['homework', homeworkId.toString()],
     queryFn: () => HomeworkApi.getHomework({ homeworkId }),
-    enabled: queryEnabled,
   });
-
-  useEffect(() => {
-    if ((user && !!accessToken) || !user) {
-      setQueryEnabled(true);
-    }
-  }, [user, accessToken]);
 
   const errorStatus = error instanceof ApiError ? error.status : null;
 

--- a/src/hooks/survey/useGetSurvey.ts
+++ b/src/hooks/survey/useGetSurvey.ts
@@ -1,30 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 
 import { ApiError } from '@/libs/errors';
 import SurveyApi from '@/services/survey';
-import useBoundStore from '@/stores';
 
 interface UseGetSurveyProps {
   surveyId: number;
 }
 
 function useGetSurvey({ surveyId }: UseGetSurveyProps) {
-  const [queryEnabled, setQueryEnabled] = useState(false);
-  const user = useBoundStore(state => state.user);
-  const accessToken = useBoundStore(state => state.accessToken);
-
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['survey', surveyId],
     queryFn: () => SurveyApi.getSurvey({ surveyId }),
-    enabled: queryEnabled,
   });
-
-  useEffect(() => {
-    if ((user && !!accessToken) || !user) {
-      setQueryEnabled(true);
-    }
-  }, [user, accessToken]);
 
   const errorStatus = error instanceof ApiError ? error.status : null;
 

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -31,7 +31,6 @@ const logout = async () => {
   resetUser();
   clearSelectedQueries(['user', 'homework', 'survey']);
 
-  if (!getAccessToken()) return;
   await axios.delete('/auth/logout', {
     baseURL: BASE_URL,
     withCredentials: true,
@@ -70,7 +69,7 @@ instance.interceptors.request.use(async config => {
     // isAutoLogin이 false이면서 user가 있는 경우(local storage에 user 정보가 남아있는 경우)
     if (user) {
       await logout();
-      window.location.href = '/';
+      // window.location.href = '/';
     }
     return config;
   }

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -7,6 +7,38 @@ import useBoundStore from '@/stores';
 
 import { ApiError } from './errors';
 
+const instance = axios.create({
+  baseURL: BASE_URL,
+  timeout: 3 * 1000,
+  withCredentials: true,
+});
+
+export const setAccessToken = (accessToken: string) => {
+  instance.defaults.headers.authorization = `Bearer ${accessToken}`;
+};
+
+export const removeAccessToken = () => {
+  delete instance.defaults.headers.authorization;
+};
+
+const getAccessToken = () => {
+  return instance.defaults.headers.authorization;
+};
+
+const logout = async () => {
+  const { resetAuthState, resetUser } = useBoundStore.getState();
+  resetAuthState();
+  resetUser();
+  clearSelectedQueries(['user', 'homework', 'survey']);
+
+  if (!getAccessToken()) return;
+  await axios.delete('/auth/logout', {
+    baseURL: BASE_URL,
+    withCredentials: true,
+  });
+  removeAccessToken();
+};
+
 // access token 재발급
 const reissueAccessToken = memoize(
   async (): Promise<string> => {
@@ -20,14 +52,7 @@ const reissueAccessToken = memoize(
       return newToken;
     } catch (refreshError) {
       // 토큰 재발급 실패 시 로그아웃 처리
-      const { resetAuthState, resetUser } = useBoundStore.getState();
-      resetAuthState();
-      resetUser();
-      await axios.delete('/auth/logout', {
-        baseURL: BASE_URL,
-        withCredentials: true,
-      });
-      clearSelectedQueries(['user', 'homework', 'survey']);
+      await logout();
       return Promise.reject(refreshError);
     }
   },
@@ -35,35 +60,39 @@ const reissueAccessToken = memoize(
   { maxAge: 2000 },
 );
 
-const instance = axios.create({
-  baseURL: BASE_URL,
-  timeout: 3 * 1000,
-  withCredentials: true,
-});
-
 // Request interceptor
-instance.interceptors.request.use(config => {
-  const { accessToken } = useBoundStore.getState();
-  if (accessToken) {
-    const configWithToken = { ...config };
-    configWithToken.headers.authorization = `Bearer ${accessToken}`;
-    return configWithToken;
+instance.interceptors.request.use(async config => {
+  const { isAutoLogin, user } = useBoundStore.getState();
+  const accessToken = getAccessToken();
+
+  // 로그인한 유저가 아닌 경우
+  if (!isAutoLogin) {
+    // isAutoLogin이 false이면서 user가 있는 경우(local storage에 user 정보가 남아있는 경우)
+    if (user) {
+      await logout();
+      window.location.href = '/';
+    }
+    return config;
   }
-  return config;
+
+  // 로그인한 유저의 access token 없을 때
+  if (!accessToken) {
+    const reissuedToken = await reissueAccessToken();
+    setAccessToken(reissuedToken);
+  }
+  const configWithToken = { ...config };
+  configWithToken.headers.authorization = getAccessToken();
+  return configWithToken;
 });
 
 // Response interceptor
 instance.interceptors.response.use(
   response => {
     const { result } = response.data;
-    if (result && result.accessToken) {
-      useBoundStore.setState({ accessToken: result.accessToken });
-    }
 
     return result;
   },
   async error => {
-    const { isAutoLogin } = useBoundStore.getState();
     console.log(error.response);
 
     const { status, data } = error.response;
@@ -73,18 +102,6 @@ instance.interceptors.response.use(
       // const { data } = error.response;
       const { errorCode } = data.result;
       if (errorCode === 'ADMIN_VALID_PERMISSION') window.location.href = '/';
-    }
-
-    if (status === 401 && isAutoLogin) {
-      // isAutoLogin: 로그인 하지 않은 사용자의 토큰 재발급 요청을 방지합니다.
-      const originalRequest = error.config;
-
-      const newToken = await reissueAccessToken();
-      useBoundStore.setState({ accessToken: newToken });
-      originalRequest.headers.authorization = `Bearer ${newToken}`;
-
-      // 이전 요청 재요청
-      return instance(originalRequest);
     }
 
     if (status >= 400 && status < 500) {

--- a/src/pages/Community/hooks/useGetPost.ts
+++ b/src/pages/Community/hooks/useGetPost.ts
@@ -5,15 +5,12 @@ import communityApi from '@/services/community';
 import useBoundStore from '@/stores';
 
 export default function useGetPost(postId: string) {
-  const { accessToken, user } = useBoundStore(state => ({
-    accessToken: state.accessToken,
-    user: state.user,
-  }));
+  const user = useBoundStore(state => state.user);
 
   const { data, isLoading, isFetched, error } = useQuery({
     queryKey: ['board', Number(postId), user?.email],
     queryFn: () => communityApi.getPost(Number(postId)),
-    enabled: /^\d+$/.test(postId) && !!accessToken,
+    enabled: /^\d+$/.test(postId) && !!user,
   });
 
   const status = error instanceof ApiError ? error.status : null;

--- a/src/stores/authSlice.ts
+++ b/src/stores/authSlice.ts
@@ -1,12 +1,10 @@
 import { StateCreator } from 'zustand';
 
 type State = {
-  accessToken: string | null;
   isAutoLogin: boolean;
 };
 
 type Actions = {
-  fetchAccessToken: (accessToken: string | null) => void;
   resetAuthState: () => void;
   setIsAutoLogin: () => void;
 };
@@ -14,13 +12,11 @@ type Actions = {
 export type AuthSlice = State & Actions;
 
 const initialState: State = {
-  accessToken: null,
   isAutoLogin: false,
 };
 
 export const createAuthSlice: StateCreator<AuthSlice> = set => ({
   ...initialState,
-  fetchAccessToken: accessToken => set({ accessToken }),
   resetAuthState: () => set(initialState),
   setIsAutoLogin: () => set({ isAutoLogin: true }),
 });


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

기존 store 에서 관리되던 accessToken 을 axios 에서 관리


## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 로그인 시 instance headers 에 accessToken을 세팅해두고 사용하는 방식으로 수정했습니다.
- 로그아웃에서 로직들 순서를 수정했습니다.
  - request에서 isAutoLogin 상태를 보고 토큰 재발급 하는 방식으로 수정되면서 store 유저 관련 상태들 먼저 다 리셋하고 로그아웃 하는 방식으로 수정했습니다. 
  - 로그아웃 클릭 시 로그아웃 요청 가는 사이에 남아있는 액세스 토큰으로 리액트 쿼리에서 get 요청을 보내는 문제가 있어서 수정했습니다.
- 기존 리액트 쿼리 활성화 조건들에서 accessToken 사용하던 부분들 수정했습니다.

---
- ### 새로고침 테스트

https://github.com/user-attachments/assets/cb258c8f-605e-4b74-90eb-2bfd5f40c445


- ### localstorage에 서 직접 isAutoLogin false로 바꾸고 새로고침하는 경우에도 로그아웃 처리했습니다.

https://github.com/user-attachments/assets/50881f1b-5e85-4f27-a78b-66b1fb36f257

- ### 리프레시 토큰 제거 테스트

https://github.com/user-attachments/assets/e7540f59-0a23-4ac1-8a39-b901040140c7



## 🔗 관련 이슈

#207 
<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
 
최대한 테스트 해보긴 했는데, 문제 생기는 부분있다면 알려주세요.