### PR TITLE
fix: 과제, 설문 캐시 문제 수정

### DIFF
--- a/src/pages/Homework/components/HomeworkForm.tsx
+++ b/src/pages/Homework/components/HomeworkForm.tsx
@@ -12,7 +12,7 @@ interface HomeworkFormProps {
 }
 
 function HomeworkForm({ homeworkId }: HomeworkFormProps) {
-  const { data: homework, isLoading, isError } = useGetHomework({ homeworkId });
+  const { data: homework, isLoading } = useGetHomework({ homeworkId });
 
   const { register, errors, reset, onSubmit, isPending } = useHomeworkForm({
     homeworkId,
@@ -26,14 +26,10 @@ function HomeworkForm({ homeworkId }: HomeworkFormProps) {
     return <HomeworkLoading />;
   }
 
-  if (isError || !homework) {
+  if (!homework) {
     return (
       <div className='flex-col-center h-[500px] gap-10 py-120'>
-        <p className='text-center'>
-          {isError
-            ? '과제 정보를 불러오는 중에 문제가 발생했습니다.'
-            : '과제 정보가 없습니다.'}
-        </p>
+        <p className='text-center'>과제 정보가 없습니다.</p>
         <Link
           to={'/'}
           className={

--- a/src/pages/Homework/index.tsx
+++ b/src/pages/Homework/index.tsx
@@ -3,10 +3,25 @@ import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import AccessError from '@/components/ErrorBoundary/AccessError';
 import Head from '@/components/Head';
+import { ApiError } from '@/libs/errors';
 import HomeworkForm from '@/pages/Homework/components/HomeworkForm';
+import useBoundStore from '@/stores';
 
 function Homework() {
   const { reset } = useQueryErrorResetBoundary();
+  const user = useBoundStore(state => state.user);
+
+  if (!user) {
+    return (
+      <AccessError
+        type={'과제'}
+        linkUrl={'/'}
+        linkString={'홈으로'}
+        error={{ status: 401 } as ApiError}
+      />
+    );
+  }
+
   return (
     <div className={'flex flex-col mt-20'}>
       <Head title={'과제 | ABCDEdu'} />

--- a/src/pages/Survey/components/SurveyForm.tsx
+++ b/src/pages/Survey/components/SurveyForm.tsx
@@ -11,7 +11,7 @@ interface SurveyFormProps {
 }
 
 function SurveyForm({ surveyId }: SurveyFormProps) {
-  const { data: survey, isError, isLoading } = useGetSurvey({ surveyId });
+  const { data: survey, isLoading } = useGetSurvey({ surveyId });
 
   const { register, errors, onSubmit, isPending } = useSurveyForm({
     surveyId,
@@ -21,14 +21,10 @@ function SurveyForm({ surveyId }: SurveyFormProps) {
     return <SurveyLoading />;
   }
 
-  if (isError || !survey) {
+  if (!survey) {
     return (
       <div className='flex-col-center h-[500px] gap-10 py-120'>
-        <p className='text-center'>
-          {isError
-            ? '설문 정보를 불러오는 중에 문제가 발생했습니다.'
-            : '설문 정보가 없습니다.'}
-        </p>
+        <p className='text-center'>설문 정보가 없습니다.</p>
         <Link
           to={'/'}
           className={

--- a/src/pages/Survey/index.tsx
+++ b/src/pages/Survey/index.tsx
@@ -3,10 +3,25 @@ import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import AccessError from '@/components/ErrorBoundary/AccessError';
 import Head from '@/components/Head';
+import { ApiError } from '@/libs/errors';
 import SurveyForm from '@/pages/Survey/components/SurveyForm';
+import useBoundStore from '@/stores';
 
 function Survey() {
   const { reset } = useQueryErrorResetBoundary();
+  const user = useBoundStore(state => state.user);
+
+  if (!user) {
+    return (
+      <AccessError
+        type={'설문'}
+        linkUrl={'/'}
+        linkString={'홈으로'}
+        error={{ status: 401 } as ApiError}
+      />
+    );
+  }
+
   return (
     <div className={'flex flex-col mt-20'}>
       <Head title={'설문 | ABCDEdu'} />


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간단한 요약을 작성하세요. -->

- 과제, 설문 로그인 전 캐시로 로그인 후에 데이터 불러오지 않는 문제 수정

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

- 과제 설문 각 페이지에서 user 없을 시에는 폼 대신 AccessError 페이지 불러오는 방식으로 수정했습니다.
- ErrorBoundary 생기면서 폼 내부의 에러 처리 로직은 제거했습니다.

https://github.com/user-attachments/assets/0300e5a6-d5dd-4fbe-9179-92034530325d




## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 제공해주세요. e.g. #123 -->

#223 

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
