### PR TITLE
fix: 댓글 목록 조회 로직 수정

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,28 +1,28 @@
-import { delay, http, HttpResponse } from 'msw';
+// import { delay, http, HttpResponse } from 'msw';
 
 import { common } from './common';
 
 export const handlers = [
   ...common,
   // 개발 환경 테스트용
-  http.get(`http://localhost:3000/api/v1/posts/31/comments`, () => {
-    return HttpResponse.json(
-      {
-        error: 'Internal Server Error',
-        message: 'An unexpected error occurred on the server.',
-      },
-      { status: 500 },
-    );
-  }),
-  http.get(`http://localhost:3000/api/v1/boards/2/posts`, () => {
-    return HttpResponse.json(null, { status: 500 });
-  }),
+  // http.get(`http://localhost:3000/api/v1/posts/31/comments`, () => {
+  //   return HttpResponse.json(
+  //     {
+  //       error: 'Internal Server Error',
+  //       message: 'An unexpected error occurred on the server.',
+  //     },
+  //     { status: 500 },
+  //   );
+  // }),
+  // http.get(`http://localhost:3000/api/v1/boards/2/posts`, () => {
+  //   return HttpResponse.json(null, { status: 500 });
+  // }),
   // http.post(`http://localhost:3000/api/v1/auth/login`, () => {
   //   return HttpResponse.json(null, { status: 500 });
   // }),
   // timemout test
-  http.get(`http://localhost:3000/api/v1/boards/1/posts`, async () => {
-    await delay('infinite');
-    return new Response();
-  }),
+  // http.get(`http://localhost:3000/api/v1/boards/1/posts`, async () => {
+  //   await delay('infinite');
+  //   return new Response();
+  // }),
 ];

--- a/src/pages/Community/components/Comments.tsx
+++ b/src/pages/Community/components/Comments.tsx
@@ -11,10 +11,15 @@ import CommentForm from './CommentForm';
 
 interface CommentsProps {
   postId: number;
+  hasComments: boolean;
   commentAllow: boolean;
 }
 
-export default function Comments({ postId, commentAllow }: CommentsProps) {
+export default function Comments({
+  postId,
+  hasComments,
+  commentAllow,
+}: CommentsProps) {
   const user = useBoundStore(state => state.user);
   const scrollTargetRef = useRef<HTMLDivElement>(null);
 
@@ -24,6 +29,7 @@ export default function Comments({ postId, commentAllow }: CommentsProps) {
   const { list, totalElements, isLoading } = useGetComments({
     postId,
     page,
+    enabled: hasComments,
   });
 
   const isAdminRole = user?.role === '관리자';

--- a/src/pages/Community/components/Post.tsx
+++ b/src/pages/Community/components/Post.tsx
@@ -52,9 +52,13 @@ export default function Post({ postId, category }: PostProps) {
         </>
       )}
       {isLevelUpButtonVisible && <LevelUpButton postId={Number(postId)} />}
-      {post && post.commentAllow && (
+      {post && (
         <ErrorBoundary onReset={reset}>
-          <Comments postId={Number(postId)} commentAllow={post.commentAllow} />
+          <Comments
+            postId={Number(postId)}
+            hasComments={post.commentCount > 0}
+            commentAllow={post.commentAllow}
+          />
         </ErrorBoundary>
       )}
     </>

--- a/src/pages/Community/hooks/useGetComments.ts
+++ b/src/pages/Community/hooks/useGetComments.ts
@@ -10,15 +10,21 @@ import communityApi from '@/services/community';
 interface UseGetCommentsProps {
   postId: number;
   page: number;
+  enabled: boolean;
 }
 
-export default function useGetComments({ postId, page }: UseGetCommentsProps) {
+export default function useGetComments({
+  postId,
+  page,
+  enabled,
+}: UseGetCommentsProps) {
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery({
     queryKey: ['comments', postId, `page-${page}`],
     queryFn: () => communityApi.getComments(postId, page),
     placeholderData: keepPreviousData,
+    enabled,
   });
 
   const list = data?.content || [];


### PR DESCRIPTION
## 📝 개요

댓글 비허용 전환 시 이전에 작성된 댓글 목록은 조회할 수 있도록 수정

![image](https://github.com/user-attachments/assets/9b84ac50-430a-4038-b11a-fc0fd6175cf4)


## 🚀 변경사항

- mock api 주석 처리

## 🔗 관련 이슈

#228

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
