### PR TITLE
fix: 비밀번호 변경 모달 닫을 때 form 초기화하도록 수정

### DIFF
--- a/src/pages/My/components/PasswordModal.tsx
+++ b/src/pages/My/components/PasswordModal.tsx
@@ -10,9 +10,14 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
   const inputStyle =
     'px-0 py-4 rounded-none border-b-1 border-zinc-300 border-neutral-500 focus:border-primary-300 text-neutral-600 transition-2';
 
-  const { errors, fieldRules, register, onSubmit } = usePasswordForm({
+  const { errors, fieldRules, register, reset, onSubmit } = usePasswordForm({
     onSuccess: onClose,
   });
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
 
   return (
     <Modal isVisible={isVisible}>
@@ -22,7 +27,7 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
             <button
               type='button'
               className='absolute top-12 right-12'
-              onClick={onClose}
+              onClick={handleClose}
             >
               <X size={24} />
             </button>
@@ -68,13 +73,13 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
             type='button'
             className='w-full h-45 px-24 text-15 
         text-primary-400 btn-white-pb font-semibold rounded-md'
-            onClick={onClose}
+            onClick={handleClose}
           >
             취소
           </button>
           <button
             type='submit'
-            className='w-full h-45 px-24 bg-primary-300 text-15 
+            className='w-full h-45 px-24 bg-primary-400 text-15 
         text-white font-semibold rounded-md'
           >
             변경사항 저장

--- a/src/pages/My/hooks/usePasswordForm.ts
+++ b/src/pages/My/hooks/usePasswordForm.ts
@@ -14,6 +14,7 @@ export default function usePasswordForm({ onSuccess }: UseAuthFormProps) {
     register,
     formState: { errors },
     handleSubmit,
+    reset,
   } = useForm<IPasswordFormInput>({ mode: 'onChange' });
 
   const fieldRules: FieldRules<IPasswordFormInput> = {
@@ -46,6 +47,7 @@ export default function usePasswordForm({ onSuccess }: UseAuthFormProps) {
       await userApi.updatePassword(newPw);
       alert('비밀번호가 변경되었습니다.');
       onSuccess();
+      reset();
     } catch (error) {
       console.log(error);
       alert('비밀번호 변경에 실패했습니다.');
@@ -55,6 +57,7 @@ export default function usePasswordForm({ onSuccess }: UseAuthFormProps) {
   const onSubmit = handleSubmit(updateAccountInfo);
 
   return {
+    reset,
     errors,
     fieldRules,
     register,


### PR DESCRIPTION
## 📝 개요

fix: 비밀번호 변경 모달 닫을 때 form 초기화하도록 수정

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#242

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
