### PR TITLE
feat: 회원가입 이메일 인증 추가

### DIFF
--- a/src/components/Header/AuthModal/EmailVerification.tsx
+++ b/src/components/Header/AuthModal/EmailVerification.tsx
@@ -1,0 +1,103 @@
+import FormErrorMessage from '@/components/FormErrorMessage';
+import Modal from '@/components/Modal';
+import Timer from '@/components/Timer';
+import useEmailVerification from '@/hooks/auth/useEmailVerification';
+import useBoundStore from '@/stores';
+
+export default function EmailVerification() {
+  const setAuthModalType = useBoundStore(state => state.setAuthModalType);
+
+  const {
+    isMailSent,
+    isPending,
+    register,
+    fieldRules,
+    errors,
+    onRequestCodeSubmit,
+    onVerifyFormSubmit,
+    timer,
+    timerKey,
+  } = useEmailVerification();
+
+  const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
+  const btnStyle =
+    'w-full h-45 px-24 bg-primary-400 text-15 text-white font-semibold rounded-md disabled:bg-primary-400/15';
+
+  return (
+    <form>
+      <Modal.Content>
+        <div className='-mt-28'>
+          <h2 className='text-24 font-semibold mb-24'>회원가입</h2>
+          <div className='flex flex-col gap-12'>
+            <div className={fieldStyle}>
+              <label htmlFor='email'>이메일</label>
+              <input
+                {...register('email', fieldRules.email)}
+                id='email'
+                type='text'
+                className='input-primary'
+                placeholder='johndoe@gmail.com'
+              />
+              {errors.email && <FormErrorMessage fieldErrors={errors.email} />}
+            </div>
+            {isMailSent && (
+              <>
+                <div className={fieldStyle}>
+                  <label htmlFor='code'>인증번호</label>
+                  <div className='flex justify-between gap-8'>
+                    <div className='w-full relative'>
+                      <input
+                        {...register('code', fieldRules.code)}
+                        id='code'
+                        type='text'
+                        className='input-primary w-full !pr-40'
+                      />
+                      <Timer
+                        initialTime={timer}
+                        timerKey={timerKey}
+                        className='absolute right-6 text-12 h-48 leading-[48px] text-red-500'
+                      />
+                    </div>
+                    <button
+                      type='button'
+                      value='requestCode'
+                      className='text-14 btn-white-pb w-fit shrink-0 px-12 rounded-md 
+                    text-primary-400 font-medium'
+                      onClick={onRequestCodeSubmit}
+                      disabled={isPending}
+                    >
+                      인증번호 재요청
+                    </button>
+                  </div>
+                  {errors.code && (
+                    <FormErrorMessage fieldErrors={errors.code} />
+                  )}
+                </div>
+                <p className='text-13 text-neutral-500'>
+                  인증번호가 메일로 발송되었습니다.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      </Modal.Content>
+      <Modal.Actions>
+        <button
+          type='submit'
+          onClick={isMailSent ? onVerifyFormSubmit : onRequestCodeSubmit}
+          className={btnStyle}
+          disabled={isPending}
+        >
+          {isMailSent ? '인증번호 확인' : '인증번호 요청'}
+        </button>
+        <button
+          type='button'
+          className='text-14 text-primary-400'
+          onClick={() => setAuthModalType('login')}
+        >
+          이미 계정이 있으신가요? 로그인하기
+        </button>
+      </Modal.Actions>
+    </form>
+  );
+}

--- a/src/components/Header/AuthModal/EmailVerification.tsx
+++ b/src/components/Header/AuthModal/EmailVerification.tsx
@@ -21,7 +21,7 @@ export default function EmailVerification() {
 
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
   const btnStyle =
-    'w-full h-45 px-24 bg-primary-400 text-15 text-white font-semibold rounded-md disabled:bg-primary-400/15';
+    'bg-primary-400 text-white rounded-md disabled:bg-primary-400/15';
 
   return (
     <form>
@@ -31,64 +31,62 @@ export default function EmailVerification() {
           <div className='flex flex-col gap-12'>
             <div className={fieldStyle}>
               <label htmlFor='email'>이메일</label>
-              <input
-                {...register('email', fieldRules.email)}
-                id='email'
-                type='text'
-                className='input-primary'
-                placeholder='johndoe@gmail.com'
-              />
+              <div className='flex justify-between gap-8'>
+                <input
+                  {...register('email', fieldRules.email)}
+                  id='email'
+                  type='text'
+                  className='input-primary w-full !pr-40'
+                  placeholder='johndoe@gmail.com'
+                />
+                <button
+                  type='button'
+                  className={`${btnStyle} w-104 h-45 px-12 text-14 shrink-0 font-medium`}
+                  onClick={onRequestCodeSubmit}
+                  disabled={isPending}
+                >
+                  {isMailSent ? '재요청' : '인증번호 요청'}
+                </button>
+              </div>
               {errors.email && <FormErrorMessage fieldErrors={errors.email} />}
             </div>
-            {isMailSent && (
-              <>
-                <div className={fieldStyle}>
-                  <label htmlFor='code'>인증번호</label>
-                  <div className='flex justify-between gap-8'>
-                    <div className='w-full relative'>
-                      <input
-                        {...register('code', fieldRules.code)}
-                        id='code'
-                        type='text'
-                        className='input-primary w-full !pr-40'
-                      />
-                      <Timer
-                        initialTime={timer}
-                        timerKey={timerKey}
-                        className='absolute right-6 text-12 h-48 leading-[48px] text-red-500'
-                      />
-                    </div>
-                    <button
-                      type='button'
-                      value='requestCode'
-                      className='text-14 btn-white-pb w-fit shrink-0 px-12 rounded-md 
-                    text-primary-400 font-medium'
-                      onClick={onRequestCodeSubmit}
-                      disabled={isPending}
-                    >
-                      인증번호 재요청
-                    </button>
-                  </div>
-                  {errors.code && (
-                    <FormErrorMessage fieldErrors={errors.code} />
+            <div className={fieldStyle}>
+              <label htmlFor='code'>인증번호</label>
+              <div className='flex justify-between gap-8'>
+                <div className='w-full relative'>
+                  <input
+                    {...register('code', fieldRules.code)}
+                    id='code'
+                    type='text'
+                    className='input-primary w-full !pr-40'
+                  />
+                  {isMailSent && (
+                    <Timer
+                      initialTime={timer}
+                      timerKey={timerKey}
+                      className='absolute right-6 text-12 h-48 leading-[48px] text-red-500'
+                    />
                   )}
                 </div>
-                <p className='text-13 text-neutral-500'>
-                  인증번호가 메일로 발송되었습니다.
-                </p>
-              </>
+              </div>
+              {errors.code && <FormErrorMessage fieldErrors={errors.code} />}
+            </div>
+            {isMailSent && (
+              <p className='text-13 text-neutral-500'>
+                인증번호가 메일로 발송되었습니다.
+              </p>
             )}
           </div>
         </div>
       </Modal.Content>
       <Modal.Actions>
         <button
-          type='submit'
-          onClick={isMailSent ? onVerifyFormSubmit : onRequestCodeSubmit}
-          className={btnStyle}
-          disabled={isPending}
+          type='button'
+          onClick={onVerifyFormSubmit}
+          className={`${btnStyle} w-full h-45 px-24 text-15 font-semibold`}
+          disabled={isPending || !isMailSent}
         >
-          {isMailSent ? '인증번호 확인' : '인증번호 요청'}
+          다음
         </button>
         <button
           type='button'

--- a/src/components/Header/AuthModal/EmailVerification.tsx
+++ b/src/components/Header/AuthModal/EmailVerification.tsx
@@ -1,4 +1,5 @@
 import FormErrorMessage from '@/components/FormErrorMessage';
+import MessageModal from '@/components/MessageModal';
 import Modal from '@/components/Modal';
 import Timer from '@/components/Timer';
 import useEmailVerification from '@/hooks/auth/useEmailVerification';
@@ -17,6 +18,9 @@ export default function EmailVerification() {
     onVerifyFormSubmit,
     timer,
     timerKey,
+    isMsgModalVisible,
+    toggleMsgModal,
+    resultErrorMsg,
   } = useEmailVerification();
 
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
@@ -96,6 +100,13 @@ export default function EmailVerification() {
           이미 계정이 있으신가요? 로그인하기
         </button>
       </Modal.Actions>
+      <MessageModal
+        isVisible={isMsgModalVisible}
+        onClose={toggleMsgModal}
+        type={'error'}
+        backdrop={false}
+        message={resultErrorMsg}
+      />
     </form>
   );
 }

--- a/src/components/Header/AuthModal/Login.tsx
+++ b/src/components/Header/AuthModal/Login.tsx
@@ -1,29 +1,23 @@
-import { X } from '@phosphor-icons/react';
-
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Modal from '@/components/Modal';
 import useLoginForm from '@/hooks/auth/useLoginForm';
-import { AuthModalActions } from '@/types/auth';
+import useBoundStore from '@/stores';
+import { AuthFormProps } from '@/types/auth';
 
-export default function Login({ onClose, onToggle }: AuthModalActions) {
+export default function Login({ onSuccess }: AuthFormProps) {
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
+
+  const setAuthModalType = useBoundStore(state => state.setAuthModalType);
 
   const { isLoginButtonDisabled, fieldRules, errors, register, onSubmit } =
     useLoginForm({
-      onSuccess: onClose,
+      onSuccess,
     });
 
   return (
     <form onSubmit={onSubmit}>
       <Modal.Content>
-        <div>
-          <button
-            type='button'
-            className='block ml-auto -mt-6 -mr-10'
-            onClick={onClose}
-          >
-            <X size={24} />
-          </button>
+        <div className='-mt-28'>
           <h2 className='text-24 font-semibold mb-24'>로그인</h2>
           <div className='flex flex-col gap-12 mb-4'>
             <div className={fieldStyle}>
@@ -52,28 +46,34 @@ export default function Login({ onClose, onToggle }: AuthModalActions) {
               )}
             </div>
           </div>
-          {/* 고도화 단계에서 개발 */}
-          {/* <Link className='flex justify-end text-14 text-primary-300' to='/'>
-            비밀번호 찾기
-          </Link> */}
         </div>
       </Modal.Content>
       <Modal.Actions>
         <button
           type='submit'
-          className='w-full h-45 px-24 bg-primary-300 text-15 
+          className='w-full h-45 px-24 bg-primary-400 text-15 
         text-white font-semibold rounded-md disabled:bg-primary-400/15'
           disabled={isLoginButtonDisabled}
         >
           로그인
         </button>
-        <button
-          type='button'
-          className='w-full text-14 text-primary-300'
-          onClick={onToggle}
-        >
-          계정 생성하기
-        </button>
+        <div className='w-full flex-row-center text-14'>
+          <button
+            type='button'
+            className='mx-8 relative text-14 text-primary-400'
+            onClick={() => setAuthModalType('register')}
+          >
+            계정 생성하기
+          </button>
+          <p className='w-1 h-21 relative pipe-after'></p>
+          <button
+            type='button'
+            className='ml-21 text-14 text-primary-400'
+            onClick={() => setAuthModalType('reset_password')}
+          >
+            비밀번호 재설정
+          </button>
+        </div>
       </Modal.Actions>
     </form>
   );

--- a/src/components/Header/AuthModal/Register.tsx
+++ b/src/components/Header/AuthModal/Register.tsx
@@ -1,38 +1,30 @@
-import { X } from '@phosphor-icons/react';
-
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Modal from '@/components/Modal';
 import useRegisterForm from '@/hooks/auth/useRegisterForm';
-import { AuthModalActions } from '@/types/auth';
+import useBoundStore from '@/stores';
 
 // 필수 항목 *
 function RequiredAsterisk() {
   return <span className='text-red-500'>*</span>;
 }
 
-export default function Register({ onClose, onToggle }: AuthModalActions) {
+export default function Register() {
   const fieldStyle = 'flex flex-col gap-4 [&>label]:text-14';
+  const email = useBoundStore(state => state.verifiedEmail);
 
   const { isRegisterButtonDisabled, errors, fieldRules, register, onSubmit } =
     useRegisterForm({
-      onSuccess: onToggle,
+      email: email ?? '',
     });
+
+  if (!email) return null;
 
   return (
     <>
-      <Modal.Header>
-        <button
-          type='button'
-          className='block ml-auto mt-4 p-2'
-          onClick={onClose}
-        >
-          <X size={24} />
-        </button>
-      </Modal.Header>
       <Modal.Content>
-        <div className='-mt-28'>
+        <form id='register' className='-mt-28' onSubmit={onSubmit}>
           <h2 className='text-24 font-semibold mb-24'>회원가입</h2>
-          <form className='flex flex-col gap-12'>
+          <div className='flex flex-col gap-12'>
             <div className={fieldStyle}>
               <label htmlFor='name'>
                 이름 <RequiredAsterisk />
@@ -47,15 +39,14 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
               {errors.name && <FormErrorMessage fieldErrors={errors.name} />}
             </div>
             <div className={fieldStyle}>
-              <label htmlFor='email'>
-                이메일 <RequiredAsterisk />
-              </label>
+              <label htmlFor='email'>이메일</label>
               <input
                 {...register('email', fieldRules.email)}
                 id='email'
                 type='text'
-                className='input-primary'
-                placeholder='johndoe@gmail.com'
+                value={email}
+                className='input-primary text-neutral-500 bg-zinc-100'
+                disabled
               />
               {errors.email && <FormErrorMessage fieldErrors={errors.email} />}
             </div>
@@ -113,25 +104,18 @@ export default function Register({ onClose, onToggle }: AuthModalActions) {
                 <FormErrorMessage fieldErrors={errors.confirmPw} />
               )}
             </div>
-          </form>
-        </div>
+          </div>
+        </form>
       </Modal.Content>
       <Modal.Actions>
         <button
+          form='register'
           type='submit'
-          className='w-full h-45 px-24 bg-primary-300 text-15 
+          className='w-full h-45 px-24 bg-primary-400 text-15 
         text-white font-semibold rounded-md disabled:bg-primary-400/15'
-          onClick={onSubmit}
           disabled={isRegisterButtonDisabled}
         >
           가입하기
-        </button>
-        <button
-          type='button'
-          className='w-full text-14 text-primary-300'
-          onClick={onToggle}
-        >
-          이미 계정이 있으신가요? 로그인하기
         </button>
       </Modal.Actions>
     </>

--- a/src/components/Header/AuthModal/index.tsx
+++ b/src/components/Header/AuthModal/index.tsx
@@ -4,14 +4,17 @@ import Modal from '@/components/Modal';
 import useBoundStore from '@/stores';
 import { AuthModalProps } from '@/types/auth';
 
+import EmailVerification from './EmailVerification';
 import Login from './Login';
 import Register from './Register';
 
 export default function AuthModal({ isVisible, onClose }: AuthModalProps) {
-  const { authModalType, resetVerificationState } = useBoundStore(state => ({
-    authModalType: state.authModalType,
-    resetVerificationState: state.resetVerificationState,
-  }));
+  const { authModalType, isEmailVerified, resetVerificationState } =
+    useBoundStore(state => ({
+      authModalType: state.authModalType,
+      isEmailVerified: state.isEmailVerified,
+      resetVerificationState: state.resetVerificationState,
+    }));
 
   const handleClose = () => {
     if (authModalType === 'register') resetVerificationState();
@@ -30,7 +33,9 @@ export default function AuthModal({ isVisible, onClose }: AuthModalProps) {
         </button>
       </Modal.Header>
       {authModalType === 'login' && <Login onSuccess={onClose} />}
-      {authModalType === 'register' && <Register />}
+      {authModalType === 'register' && (
+        <>{isEmailVerified ? <Register /> : <EmailVerification />}</>
+      )}
     </Modal>
   );
 }

--- a/src/components/Header/AuthModal/index.tsx
+++ b/src/components/Header/AuthModal/index.tsx
@@ -1,24 +1,36 @@
+import { X } from '@phosphor-icons/react';
+
 import Modal from '@/components/Modal';
+import useBoundStore from '@/stores';
 import { AuthModalProps } from '@/types/auth';
 
 import Login from './Login';
 import Register from './Register';
 
-export default function AuthModal({
-  type = 'login',
-  isVisible,
-  onClose,
-  onToggle,
-}: AuthModalProps) {
-  const IS_LOGIN_MODAL = type === 'login';
+export default function AuthModal({ isVisible, onClose }: AuthModalProps) {
+  const { authModalType, resetVerificationState } = useBoundStore(state => ({
+    authModalType: state.authModalType,
+    resetVerificationState: state.resetVerificationState,
+  }));
+
+  const handleClose = () => {
+    if (authModalType === 'register') resetVerificationState();
+    onClose();
+  };
 
   return (
     <Modal isVisible={isVisible}>
-      {IS_LOGIN_MODAL ? (
-        <Login onToggle={onToggle} onClose={onClose} />
-      ) : (
-        <Register onToggle={onToggle} onClose={onClose} />
-      )}
+      <Modal.Header>
+        <button
+          type='button'
+          className='block ml-auto mt-4 p-2'
+          onClick={handleClose}
+        >
+          <X size={24} />
+        </button>
+      </Modal.Header>
+      {authModalType === 'login' && <Login onSuccess={onClose} />}
+      {authModalType === 'register' && <Register />}
     </Modal>
   );
 }

--- a/src/components/Header/HeaderButtons.tsx
+++ b/src/components/Header/HeaderButtons.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import UserLogin from '@/assets/icons/user-login.svg?react';
@@ -54,21 +53,21 @@ function MemberButtons() {
 
 function GuestButtons() {
   const { isVisible, toggleModal } = useModal();
-  const [modalType, setModalType] = useState<AuthModalType>('login');
-  const setIsSidebarOpen = useBoundStore(state => state.setIsSidebarOpen);
+
+  const { setIsSidebarOpen, setAuthModalType } = useBoundStore(state => ({
+    setIsSidebarOpen: state.setIsSidebarOpen,
+    setAuthModalType: state.setAuthModalType,
+  }));
 
   const handleClick = (type: AuthModalType) => {
     toggleModal();
-    setModalType(type);
+    setAuthModalType(type);
   };
 
   const handleClose = () => {
     toggleModal();
+    setAuthModalType('login');
     setIsSidebarOpen(false);
-  };
-
-  const toggleModalType = () => {
-    setModalType(modalType === 'login' ? 'register' : 'login');
   };
 
   return (
@@ -85,12 +84,7 @@ function GuestButtons() {
       >
         회원가입
       </button>
-      <AuthModal
-        type={modalType}
-        isVisible={isVisible}
-        onClose={handleClose}
-        onToggle={toggleModalType}
-      />
+      <AuthModal isVisible={isVisible} onClose={handleClose} />
     </>
   );
 }

--- a/src/components/MessageModal.tsx
+++ b/src/components/MessageModal.tsx
@@ -44,7 +44,9 @@ function MessageModal({
             <ExclamationMark className={'w-55 h-55 text-primary-300'} />
           )}
 
-          <div className={'text-18 font-semibold'}>{message}</div>
+          <div className='text-18 font-semibold whitespace-pre-line text-center'>
+            {message}
+          </div>
         </div>
       </Modal.Content>
     </Modal>

--- a/src/components/MessageModal.tsx
+++ b/src/components/MessageModal.tsx
@@ -1,3 +1,5 @@
+import { X } from '@phosphor-icons/react';
+
 import CheckCircle from '@/assets/icons/check-circle.svg?react';
 import ExclamationMark from '@/assets/icons/exclamation-mark.svg?react';
 import Modal from '@/components/Modal';
@@ -7,6 +9,7 @@ interface MessageModalProps {
   onClose: () => void;
   type: 'success' | 'error';
   message: string;
+  backdrop?: boolean;
 }
 
 function MessageModal({
@@ -14,11 +17,27 @@ function MessageModal({
   onClose,
   type,
   message,
+  backdrop = true,
 }: MessageModalProps) {
   return (
-    <Modal size={'sm'} isVisible={isVisible} onClose={onClose}>
+    <Modal
+      showBackdrop={backdrop}
+      size={'sm'}
+      isVisible={isVisible}
+      onClose={onClose}
+    >
+      <Modal.Header>
+        <button
+          type='button'
+          aria-label='닫기'
+          className='block ml-auto mt-4 p-2'
+          onClick={onClose}
+        >
+          <X size={24} />
+        </button>
+      </Modal.Header>
       <Modal.Content>
-        <div className={'py-20 flex-col-center gap-20'}>
+        <div className={'-mt-16 pb-20 flex-col-center gap-20'}>
           {type === 'success' ? (
             <CheckCircle className={'w-55 h-55 text-primary-300'} />
           ) : (

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -53,7 +53,7 @@ export default function Modal({
             <motion.div
               role='dialog'
               className={`fixed z-modal bg-white position-center rounded-md 
-                max-h-[calc(100dvh_-_16px)] flex flex-col ${getSizingStyle()} ${mobileFullStyle}`}
+                max-h-[calc(100dvh_-_16px)] flex flex-col ${getSizingStyle()} ${mobileFullStyle} shadow-modal`}
               onClick={e => e.stopPropagation()}
               initial='hidden'
               animate='visible'

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface TimerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  initialTime: number;
+  timerKey: number; // timerKey가 바뀌면 timer 재실행
+}
+
+function Timer({ initialTime, timerKey, ...rest }: TimerProps) {
+  const timerRef = useRef<number>(initialTime);
+  const timerIdRef = useRef<NodeJS.Timeout | null>(null);
+  const spanRef = useRef<HTMLSpanElement | null>(null);
+
+  const formatTimer = (time: number) => {
+    const min = Math.floor(time / 60)
+      .toString()
+      .padStart(2, '0');
+    const sec = (time % 60).toString().padStart(2, '0');
+
+    return `${min}:${sec}`;
+  };
+
+  // timer 초기화 및 시작
+  const startTimer = useCallback(() => {
+    timerRef.current = initialTime;
+
+    if (spanRef.current) {
+      spanRef.current.textContent = formatTimer(timerRef.current); // initialTime 텍스트 설정
+    }
+
+    // 이전 타이머 제거
+    if (timerIdRef.current) {
+      clearInterval(timerIdRef.current);
+    }
+
+    // 타이머 설정
+    timerIdRef.current = setInterval(() => {
+      if (timerRef.current > 0) {
+        timerRef.current -= 1;
+        if (spanRef.current) {
+          spanRef.current.textContent = formatTimer(timerRef.current);
+        }
+      } else {
+        clearInterval(timerIdRef.current!);
+      }
+    }, 1000);
+  }, [initialTime]);
+
+  useEffect(() => {
+    startTimer();
+    return () => clearInterval(timerIdRef.current!);
+  }, [timerKey, startTimer]);
+
+  return <span ref={spanRef} {...rest}></span>;
+}
+
+export default Timer;

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -71,7 +71,11 @@ export default function useEmailVerification() {
     const { email, code } = data;
 
     if (!code) {
-      setError('code', { type: 'manual', message: '인증번호를 입력하세요.' });
+      setError(
+        'code',
+        { type: 'manual', message: '인증번호를 입력하세요.' },
+        { shouldFocus: true },
+      );
       return;
     }
 

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { ApiError } from '@/libs/errors';
+import authApi from '@/services/auth';
+import useBoundStore from '@/stores';
+import { FieldRules } from '@/types';
+
+interface EmailVerificationInput {
+  email: string;
+  code: string;
+}
+
+export default function useEmailVerification() {
+  const [isMailSent, setIsMailSent] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+
+  const [timer, setTimer] = useState(300); // 5분 타이머
+  const [timerKey, setTimerKey] = useState(1);
+
+  const { setIsEmailVerified, setVerifiedEmail } = useBoundStore(state => ({
+    setIsEmailVerified: state.setIsEmailVerified,
+    setVerifiedEmail: state.setVerifiedEmail,
+  }));
+
+  const {
+    register,
+    formState: { errors },
+    setError,
+    handleSubmit,
+  } = useForm<EmailVerificationInput>();
+
+  const fieldRules: FieldRules<EmailVerificationInput> = {
+    email: {
+      required: '이메일을 입력하세요.',
+      pattern: {
+        value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+        message: '올바르지 않은 이메일 형식입니다.',
+      },
+    },
+    code: {},
+  };
+
+  // 인증번호 요청
+  const handleRequestSubmit: SubmitHandler<EmailVerificationInput> = async (
+    data,
+    e,
+  ) => {
+    e?.preventDefault();
+    setIsPending(true);
+
+    try {
+      await authApi.requestVerificationCode(data.email);
+      setTimer(300);
+      setTimerKey(prev => prev + 1);
+      setIsMailSent(true);
+    } catch (error) {
+      console.log(error);
+      alert('인증번호 요청에 실패했습니다.');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  // 인증번호 검증
+  const handleVerifySubmit: SubmitHandler<EmailVerificationInput> = async (
+    data,
+    e,
+  ) => {
+    e?.preventDefault();
+    const { email, code } = data;
+
+    if (!code) {
+      setError('code', { type: 'manual', message: '인증번호를 입력하세요.' });
+      return;
+    }
+
+    setIsPending(true);
+
+    try {
+      await authApi.verifyCode(email, code);
+      alert('이메일 인증이 완료되었습니다.');
+      setIsEmailVerified();
+      setVerifiedEmail(email);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 400) alert('인증번호가 일치하지 않습니다.');
+        if (error.status === 404)
+          alert(
+            '인증번호가 유효하지 않거나 만료되었습니다.\n인증번호를 다시 요청해 주세요.',
+          );
+      } else {
+        console.log(error);
+        alert('이메일 인증에 실패했습니다.');
+      }
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const onVerifyFormSubmit = handleSubmit(handleVerifySubmit);
+  const onRequestCodeSubmit = handleSubmit(handleRequestSubmit);
+
+  return {
+    isMailSent,
+    isPending,
+    register,
+    fieldRules,
+    errors,
+    onVerifyFormSubmit,
+    onRequestCodeSubmit,
+    timer,
+    timerKey,
+  };
+}

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -6,6 +6,8 @@ import authApi from '@/services/auth';
 import useBoundStore from '@/stores';
 import { FieldRules } from '@/types';
 
+import useModal from '../useModal';
+
 interface EmailVerificationInput {
   email: string;
   code: string;
@@ -17,6 +19,11 @@ export default function useEmailVerification() {
 
   const [timer, setTimer] = useState(300); // 5분 타이머
   const [timerKey, setTimerKey] = useState(1);
+
+  const [resultErrorMsg, setResultErrorMsg] = useState(''); // 검증 실패 시 오류 메시지
+
+  const { isVisible: isMsgModalVisible, toggleModal: toggleMsgModal } =
+    useModal();
 
   const { setIsEmailVerified, setVerifiedEmail } = useBoundStore(state => ({
     setIsEmailVerified: state.setIsEmailVerified,
@@ -89,15 +96,17 @@ export default function useEmailVerification() {
       setVerifiedEmail(email);
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.status === 400) alert('인증번호가 일치하지 않습니다.');
+        if (error.status === 400)
+          setResultErrorMsg('인증번호가 일치하지 않습니다.');
         if (error.status === 404)
-          alert(
+          setResultErrorMsg(
             '인증번호가 유효하지 않거나 만료되었습니다.\n인증번호를 다시 요청해 주세요.',
           );
       } else {
         console.log(error);
         alert('이메일 인증에 실패했습니다.');
       }
+      toggleMsgModal();
     } finally {
       setIsPending(false);
     }
@@ -116,5 +125,8 @@ export default function useEmailVerification() {
     onRequestCodeSubmit,
     timer,
     timerKey,
+    isMsgModalVisible,
+    toggleMsgModal,
+    resultErrorMsg,
   };
 }

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -47,6 +47,7 @@ export default function useEmailVerification() {
     e,
   ) => {
     e?.preventDefault();
+    setIsMailSent(false);
     setIsPending(true);
 
     try {

--- a/src/hooks/auth/useLoginForm.ts
+++ b/src/hooks/auth/useLoginForm.ts
@@ -6,14 +6,14 @@ import { ApiError } from '@/libs/errors';
 import auth from '@/services/auth';
 import useBoundStore from '@/stores';
 import { FieldRules } from '@/types';
-import { UseAuthFormProps } from '@/types/auth';
+import { AuthFormProps } from '@/types/auth';
 
 interface ILoginFormInput {
   email: string;
   password: string;
 }
 
-export default function useLoginForm({ onSuccess }: UseAuthFormProps) {
+export default function useLoginForm({ onSuccess }: AuthFormProps) {
   const setIsAutoLogin = useBoundStore(state => state.setIsAutoLogin);
 
   const {

--- a/src/pages/My/hooks/usePasswordForm.ts
+++ b/src/pages/My/hooks/usePasswordForm.ts
@@ -2,14 +2,14 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 
 import userApi from '@/services/user';
 import { FieldRules } from '@/types';
-import { UseAuthFormProps } from '@/types/auth';
+import { AuthFormProps } from '@/types/auth';
 
 interface IPasswordFormInput {
   newPw: string;
   confirmPw: string;
 }
 
-export default function usePasswordForm({ onSuccess }: UseAuthFormProps) {
+export default function usePasswordForm({ onSuccess }: AuthFormProps) {
   const {
     register,
     formState: { errors },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,9 +1,17 @@
-import { del, post } from '@/libs/api';
+import { del, get, post } from '@/libs/api';
 import { RegisterForm, TokenResponse } from '@/types/auth';
 
 class AuthApi {
   static async signUp(form: RegisterForm) {
     return post('/auth/signup', form);
+  }
+
+  static async requestVerificationCode(email: string) {
+    return post('/mail/code', { email });
+  }
+
+  static async verifyCode(email: string, code: string) {
+    return get('/mail/code', { params: { email, code } });
   }
 
   static async login(email: string, password: string) {

--- a/src/stores/authSlice.ts
+++ b/src/stores/authSlice.ts
@@ -1,22 +1,28 @@
 import { StateCreator } from 'zustand';
 
+import { AuthModalType } from '@/types/auth';
+
 type State = {
   isAutoLogin: boolean;
+  authModalType: AuthModalType;
 };
 
 type Actions = {
   resetAuthState: () => void;
   setIsAutoLogin: () => void;
+  setAuthModalType: (authModalType: AuthModalType) => void;
 };
 
 export type AuthSlice = State & Actions;
 
 const initialState: State = {
   isAutoLogin: false,
+  authModalType: 'login',
 };
 
 export const createAuthSlice: StateCreator<AuthSlice> = set => ({
   ...initialState,
   resetAuthState: () => set(initialState),
   setIsAutoLogin: () => set({ isAutoLogin: true }),
+  setAuthModalType: authModalType => set({ authModalType }),
 });

--- a/src/stores/emailVerificationSlice.ts
+++ b/src/stores/emailVerificationSlice.ts
@@ -1,0 +1,29 @@
+import { StateCreator } from 'zustand';
+
+// 이메일 인증 관련 state
+type State = {
+  isEmailVerified: boolean; // 인증 여부
+  verifiedEmail: string | null; // 인증된 이메일
+};
+
+type Actions = {
+  resetVerificationState: () => void;
+  setIsEmailVerified: () => void;
+  setVerifiedEmail: (verifiedEmail: string) => void;
+};
+
+export type EmailVerificationSlice = State & Actions;
+
+const initialState: State = {
+  isEmailVerified: false,
+  verifiedEmail: null,
+};
+
+export const createEmailVerificationSlice: StateCreator<
+  EmailVerificationSlice
+> = set => ({
+  ...initialState,
+  resetVerificationState: () => set(initialState),
+  setIsEmailVerified: () => set({ isEmailVerified: true }),
+  setVerifiedEmail: verifiedEmail => set({ verifiedEmail }),
+});

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,15 +2,20 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 import { AuthSlice, createAuthSlice } from './authSlice';
+import {
+  EmailVerificationSlice,
+  createEmailVerificationSlice,
+} from './emailVerificationSlice';
 import { createHeaderSlice, HeaderSlice } from './headerSlice';
 import { UserSlice, createUserSlice } from './userSlice';
 
-type StoreState = AuthSlice & UserSlice & HeaderSlice;
+type StoreState = AuthSlice & EmailVerificationSlice & UserSlice & HeaderSlice;
 
 const useBoundStore = create<StoreState>()(
   persist(
     (set, get, api) => ({
       ...createAuthSlice(set, get, api),
+      ...createEmailVerificationSlice(set, get, api),
       ...createUserSlice(set, get, api),
       ...createHeaderSlice(set, get, api),
     }),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,15 +1,11 @@
-export type AuthModalType = 'login' | 'register';
+export type AuthModalType = 'login' | 'register' | 'reset_password';
 
 export interface AuthModalProps {
-  type?: AuthModalType;
   isVisible: boolean;
   onClose: () => void;
-  onToggle: () => void;
 }
 
-export type AuthModalActions = Pick<AuthModalProps, 'onClose' | 'onToggle'>;
-
-export interface UseAuthFormProps {
+export interface AuthFormProps {
   onSuccess: () => void;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,6 +70,8 @@ export default {
         'btn-light': '2px 2px 4px 0px rgba(41, 37, 110, 0.1)',
         'card-lg': '0px 12px 40px 2px rgba(0,0,0,0.08)',
         'card-md': '0px 20.98px 41.96px -10.49px rgba(41, 37, 110, 0.1)',
+        modal:
+          '0px 10px 32px 4px rgba(24, 39, 75, 0.05), 0px 6px 14px 4px rgba(24, 39, 75, 0.12)',
       },
     },
   },


### PR DESCRIPTION
## 📝 개요

회원가입 이메일 인증 추가

아직 백엔드 비동기 처리가 안 되어서 기다리는 시간이 있습니다. (+ 5초에서도 timeout이 뜰 때가 있네요..)

- 기본 동작 + 인증 실패할 경우

https://github.com/user-attachments/assets/737ef6c0-4387-400b-be9c-d00f7e77e2eb

<br/>

- 인증 성공

https://github.com/user-attachments/assets/77d8e848-acc4-4d3b-a260-b8fe312039f8

가입 도중 모달을 닫으면 회원가입 처음부터 진행


## 🚀 변경사항

- 이메일 인증 및 비밀번호 재설정 모달이 추가되면서 모달 타입을 전역으로 관리하도록 변경했습니다.

## 🔗 관련 이슈

#237

## ➕ 기타

비밀번호 재설정도 작업은 해두었는데 같이 올리기엔 많아서 이거 머지되면 따로 올리겠습니다.
백엔드에서 비동기로 바뀌고 나면 dev 환경에서 추가로 테스트 진행할 예정입니다.

- 지금 코드에서는 인증번호 재요청할 때 `isMailSent`를 다시 false로 초기화해서 요청중일 때 일시적으로 버튼 텍스트가 '인증번호 요청'으로 다시 바뀌게 되는데 그냥 '재요청'을 쓰지 않고 '인증번호 요청'으로 텍스트를 고정할지 고민이 되네요. 
- UI/UX 관련해서 의견이 있으시면 말씀해 주세요!


<br/>
