### PR TITLE
feat: 비밀번호 재설정 구현

### DIFF
--- a/src/components/Header/AuthModal/ResetPassword.tsx
+++ b/src/components/Header/AuthModal/ResetPassword.tsx
@@ -42,7 +42,7 @@ export default function ResetPassword() {
           rounded-md disabled:bg-primary-400/15'
           disabled={isPending}
         >
-          임시 비밀번호 발급
+          {isMailSent ? '재발급' : '임시 비밀번호 발급'}
         </button>
         <button
           type='button'

--- a/src/components/Header/AuthModal/ResetPassword.tsx
+++ b/src/components/Header/AuthModal/ResetPassword.tsx
@@ -1,0 +1,57 @@
+import FormErrorMessage from '@/components/FormErrorMessage';
+import Modal from '@/components/Modal';
+import useResetPassword from '@/hooks/auth/useResetPassword';
+import useBoundStore from '@/stores';
+
+export default function ResetPassword() {
+  const setAuthModalType = useBoundStore(state => state.setAuthModalType);
+
+  const { isMailSent, isPending, errors, register, fieldRules, onSubmit } =
+    useResetPassword();
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Modal.Content>
+        <div className='-mt-28'>
+          <h2 className='text-24 font-semibold mb-24'>비밀번호 재설정</h2>
+          <div className='flex flex-col gap-8'>
+            <div className='flex flex-col gap-4 [&>label]:text-14'>
+              <label htmlFor='email'>이메일</label>
+              <input
+                {...register('email', fieldRules.email)}
+                id='email'
+                type='text'
+                className='input-primary'
+                placeholder='johndoe@gmail.com'
+              />
+              {errors.email && <FormErrorMessage fieldErrors={errors.email} />}
+            </div>
+            {isMailSent && (
+              <p className='text-13 text-neutral-500'>
+                임시 비밀번호가 메일로 발송되었습니다. 로그인 후 비밀번호를
+                변경해 주세요.
+              </p>
+            )}
+          </div>
+        </div>
+      </Modal.Content>
+      <Modal.Actions>
+        <button
+          type='submit'
+          className='w-full h-45 px-24 bg-primary-400 text-15 text-white font-semibold 
+          rounded-md disabled:bg-primary-400/15'
+          disabled={isPending}
+        >
+          임시 비밀번호 발급
+        </button>
+        <button
+          type='button'
+          className='w-full text-14 text-primary-400'
+          onClick={() => setAuthModalType('login')}
+        >
+          로그인으로 돌아가기
+        </button>
+      </Modal.Actions>
+    </form>
+  );
+}

--- a/src/components/Header/AuthModal/index.tsx
+++ b/src/components/Header/AuthModal/index.tsx
@@ -7,6 +7,7 @@ import { AuthModalProps } from '@/types/auth';
 import EmailVerification from './EmailVerification';
 import Login from './Login';
 import Register from './Register';
+import ResetPassword from './ResetPassword';
 
 export default function AuthModal({ isVisible, onClose }: AuthModalProps) {
   const { authModalType, isEmailVerified, resetVerificationState } =
@@ -36,6 +37,7 @@ export default function AuthModal({ isVisible, onClose }: AuthModalProps) {
       {authModalType === 'register' && (
         <>{isEmailVerified ? <Register /> : <EmailVerification />}</>
       )}
+      {authModalType === 'reset_password' && <ResetPassword />}
     </Modal>
   );
 }

--- a/src/hooks/auth/useResetPassword.ts
+++ b/src/hooks/auth/useResetPassword.ts
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { ApiError } from '@/libs/errors';
+import authApi from '@/services/auth';
+import { FieldRules } from '@/types';
+
+interface IResetPasswordForm {
+  email: string;
+}
+
+export default function useResetPassword() {
+  const [isMailSent, setIsMailSent] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<IResetPasswordForm>({ mode: 'onBlur' });
+
+  const fieldRules: FieldRules<IResetPasswordForm> = {
+    email: {
+      required: '이메일을 입력하세요.',
+      pattern: {
+        value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+        message: '올바르지 않은 이메일 형식입니다.',
+      },
+    },
+  };
+
+  const requestTempPassword: SubmitHandler<IResetPasswordForm> = async (
+    data,
+    e,
+  ) => {
+    e?.preventDefault();
+    setIsPending(true);
+    try {
+      // 임시 비밀번호 발급 요청
+      await authApi.requestTempPassword(data.email);
+      setIsMailSent(prev => !prev);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        // 존재하지 않는 이메일 처리
+        if (error.status === 404) alert('존재하지 않는 이메일입니다.');
+      } else {
+        console.log(error);
+        alert('임시 비밀번호 발급 요청에 실패했습니다.');
+      }
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const onSubmit = handleSubmit(requestTempPassword);
+
+  return {
+    isMailSent,
+    isPending,
+    errors,
+    register,
+    fieldRules,
+    onSubmit,
+  };
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -14,6 +14,10 @@ class AuthApi {
     return get('/mail/code', { params: { email, code } });
   }
 
+  static async requestTempPassword(email: string) {
+    return post('/mail/temp-password', { email });
+  }
+
   static async login(email: string, password: string) {
     return post<TokenResponse>('/auth/login', {
       email,


### PR DESCRIPTION
## 📝 개요

비밀번호 재설정 (임시 비밀번호 발급) 구현

https://github.com/user-attachments/assets/907987cf-2a2c-428c-aa3a-f7d2c22e4e68

영상에는 반영이 안 되어 있는데 이메일 인증과 마찬가지로 발급 요청에 성공하면 '임시 비밀번호 발급' → '재발급'으로 버튼 텍스트가 바뀌도록 했습니다.

## 🚀 변경사항

<!-- 이 PR에 의해 변경되는 사항에 대해 자세히 설명해주세요.
변경된 코드의 특정 부분을 강조하거나, 스크린샷을 첨부하면 reviewer에게 도움이 됩니다. -->

## 🔗 관련 이슈

#240 

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
