### PR TITLE
test: 프로필 페이지 테스트 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ tsconfig.node.tsbuildinfo
 tsconfig.tsbuildinfo
 vite.config.d.ts
 vite.config.js
+
+#test
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@sentry/vite-plugin": "^2.22.5",
         "@testing-library/jest-dom": "^6.6.1",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/node": "^22.5.4",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -2562,6 +2563,19 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "@vitejs/plugin-react-swc": "^3.5.0",
+        "@vitest/coverage-v8": "^2.1.3",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.49.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -460,6 +461,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.0",
@@ -1219,6 +1226,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2880,6 +2896,47 @@
       },
       "peerDependencies": {
         "vite": "^4 || ^5"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.3.tgz",
+      "integrity": "sha512-2OJ3c7UPoFSmBZwqD2VEkUw6A/tzPF0LmW0ZZhhB8PFxuc+9IBG/FaSM+RLEenc7ljzFvGN+G0nGQoZnh7sy2A==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.6",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.11",
+        "magicast": "^0.3.4",
+        "std-env": "^3.7.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.3",
+        "vitest": "2.1.3"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -5727,6 +5784,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6334,6 +6397,56 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -6862,6 +6975,32 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/memoize": {
@@ -8945,6 +9084,55 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@sentry/vite-plugin": "^2.22.5",
     "@testing-library/jest-dom": "^6.6.1",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.5.4",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "prepare": "husky",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.7",
@@ -47,6 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitest/coverage-v8": "^2.1.3",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.49.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/src/__test__/customRender.tsx
+++ b/src/__test__/customRender.tsx
@@ -1,14 +1,21 @@
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, RenderOptions } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 
-import { queryClient } from '@/libs/react-query';
-
 function RenderWithProviders({ children }: PropsWithChildren) {
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
   return (
     <HelmetProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={testQueryClient}>
+        {children}
+      </QueryClientProvider>
     </HelmetProvider>
   );
 }

--- a/src/__test__/customRender.tsx
+++ b/src/__test__/customRender.tsx
@@ -1,0 +1,21 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, RenderOptions } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+
+import { queryClient } from '@/libs/react-query';
+
+function RenderWithProviders({ children }: PropsWithChildren) {
+  return (
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </HelmetProvider>
+  );
+}
+
+export default function customRender(
+  ui: React.ReactElement,
+  options?: RenderOptions,
+) {
+  return render(ui, { wrapper: RenderWithProviders, ...options });
+}

--- a/src/__test__/mockSelectFile.ts
+++ b/src/__test__/mockSelectFile.ts
@@ -1,0 +1,20 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export function mockSelectFile(
+  inputId = 'file-input',
+  fileName = 'test.png',
+  fileType = 'image/png',
+  fileSizeInMB = 1,
+) {
+  const user = userEvent.setup();
+
+  const fileContent = new Uint8Array(fileSizeInMB * 1024 * 1024);
+  const filePath = [`C:\\fakepath\\${fileName}`];
+  const file = new File([fileContent], fileName, { type: fileType });
+
+  const fileInput = screen.getByTestId(inputId);
+  const select = () => user.upload(fileInput, file);
+
+  return { fileInput, filePath, select };
+}

--- a/src/components/FormErrorMessage.tsx
+++ b/src/components/FormErrorMessage.tsx
@@ -1,14 +1,22 @@
 import { FieldError } from 'react-hook-form';
 
+interface FormErrorMessageProps extends React.HTMLAttributes<HTMLSpanElement> {
+  fieldErrors: FieldError;
+  size?: 'xs' | 'base';
+}
+
 export default function FormErrorMessage({
   fieldErrors,
   size = 'xs',
-}: {
-  fieldErrors: FieldError;
-  size?: 'xs' | 'base';
-}) {
+  className,
+  ...rest
+}: FormErrorMessageProps) {
   return (
-    <span role='alert' className={`text-${size} text-red-500`}>
+    <span
+      role='alert'
+      className={`text-${size} text-red-500 ${className}`}
+      {...rest}
+    >
       {fieldErrors.message}
     </span>
   );

--- a/src/components/Portal.test.tsx
+++ b/src/components/Portal.test.tsx
@@ -3,16 +3,16 @@ import { render, screen } from '@testing-library/react';
 import Portal from './Portal';
 
 describe('components/Portal', () => {
-  it('정의되어 있어야 한다', () => {
+  test('정의되어 있어야 한다', () => {
     expect(Portal).toBeDefined();
   });
 
-  it('children을 렌더링한다', () => {
+  test('children을 렌더링한다', () => {
     render(<Portal>children</Portal>);
     expect(screen.getByText('children')).toBeInTheDocument();
   });
 
-  it('children을 document.body에 렌더링한다', () => {
+  test('children을 document.body에 렌더링한다', () => {
     const { container } = render(<Portal>children</Portal>);
     expect(container.firstChild).not.toBeInTheDocument();
     expect(document.body).toHaveTextContent('children');

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -19,5 +19,11 @@ export default function Skeleton({
     borderRadius: `${radius}px`,
   };
 
-  return <div className='animate-skeleton' style={{ ...size, ...style }} />;
+  return (
+    <div
+      className='animate-skeleton'
+      role='status'
+      style={{ ...size, ...style }}
+    />
+  );
 }

--- a/src/pages/My/components/PasswordModal.test.tsx
+++ b/src/pages/My/components/PasswordModal.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import userApi from '@/services/user';
+
+import PasswordModal from './PasswordModal';
+
+const user = userEvent.setup();
+
+const windowMock = {
+  scrollTo: vi.fn(),
+  alert: vi.fn(),
+};
+
+Object.assign(global, windowMock);
+
+describe('PasswordModal', () => {
+  test('비밀번호가 6자보다 적거나 20자보다 많으면 오류 메시지를 보여준다.', async () => {
+    render(<PasswordModal isVisible onClose={vi.fn()} />);
+    const newPasswordInput = screen.getByLabelText('새 비밀번호');
+
+    await user.type(newPasswordInput, 'qwert');
+    expect(
+      screen.getByText('비밀번호는 최소 6자 이상이어야 합니다.'),
+    ).toBeInTheDocument();
+
+    await user.type(newPasswordInput, 'asdfzxcv12345678');
+    expect(
+      screen.getByText('비밀번호는 최대 20자까지 입력할 수 있습니다.'),
+    ).toBeInTheDocument();
+  });
+
+  test('비밀번호 확인이 비밀번호와 일치하지 않으면 오류 메시지를 보여준다.', async () => {
+    render(<PasswordModal isVisible onClose={vi.fn()} />);
+    const newPasswordInput = screen.getByLabelText('새 비밀번호');
+    const confirmPasswordInput = screen.getByLabelText('새 비밀번호 확인');
+
+    await user.type(newPasswordInput, 'qwerty');
+    expect(
+      screen.queryByText('비밀번호는 최소 6자 이상이어야 합니다.'),
+    ).not.toBeInTheDocument();
+
+    await user.type(confirmPasswordInput, 'qwertx');
+    expect(
+      screen.getByText('비밀번호가 일치하지 않습니다.'),
+    ).toBeInTheDocument();
+  });
+
+  test('비밀번호 변경에 성공하면 성공 메시지를 띄우고 onClose가 실행된다.', async () => {
+    const mockOnClose = vi.fn();
+    vi.spyOn(userApi, 'updatePassword').mockResolvedValueOnce({}); // 성공 응답 모킹
+
+    render(<PasswordModal isVisible onClose={mockOnClose} />);
+
+    const newPasswordInput = screen.getByLabelText('새 비밀번호');
+    const confirmPasswordInput = screen.getByLabelText('새 비밀번호 확인');
+
+    await user.type(newPasswordInput, 'qwerty');
+    await user.type(confirmPasswordInput, 'qwerty');
+
+    const saveButton = screen.getByText('변경사항 저장');
+    await user.click(saveButton);
+
+    expect(window.alert).toHaveBeenCalledWith('비밀번호가 변경되었습니다.');
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
+  test('비밀 번호 변경에 실패하면 오류 메시지를 띄운다.', async () => {
+    vi.spyOn(userApi, 'updatePassword').mockRejectedValueOnce({}); // 실패 응답 모킹
+
+    render(<PasswordModal isVisible onClose={vi.fn()} />);
+
+    const newPasswordInput = screen.getByLabelText('새 비밀번호');
+    const confirmPasswordInput = screen.getByLabelText('새 비밀번호 확인');
+
+    await user.type(newPasswordInput, 'qwerty');
+    await user.type(confirmPasswordInput, 'qwerty');
+
+    const saveButton = screen.getByText('변경사항 저장');
+    await user.click(saveButton);
+
+    expect(window.alert).toHaveBeenCalledWith('비밀번호 변경에 실패했습니다.');
+  });
+
+  test('취소 또는 닫기 버튼을 클릭하면 onClose가 실행된다.', async () => {
+    const mockOnClose = vi.fn();
+    render(<PasswordModal isVisible onClose={mockOnClose} />);
+
+    const cancelButton = screen.getByText('취소');
+    await user.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalledOnce();
+
+    mockOnClose.mockClear();
+
+    const closeButton = screen.getByRole('button', { name: '닫기' });
+    await user.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/My/components/PasswordModal.tsx
+++ b/src/pages/My/components/PasswordModal.tsx
@@ -1,5 +1,6 @@
 import { X } from '@phosphor-icons/react';
 
+import FormErrorMessage from '@/components/FormErrorMessage';
 import Modal from '@/components/Modal';
 
 import usePasswordForm from '../hooks/usePasswordForm';
@@ -34,9 +35,11 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
             <h2 className='text-20 text-center font-semibold pt-12 mb-24'>
               비밀번호 변경
             </h2>
-            <div className='flex flex-col gap-20 mb-4 [&_span]:text-14'>
+            <div className='flex flex-col gap-20 mb-4'>
               <div className={fieldStyle}>
-                <span>새 비밀번호</span>
+                <label htmlFor='newPw' className='text-14'>
+                  새 비밀번호
+                </label>
                 <input
                   {...register('newPw', fieldRules.newPw)}
                   id='newPw'
@@ -45,13 +48,16 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
                   className={inputStyle}
                 />
                 {errors.newPw && (
-                  <span className='!text-12 mt-2 text-red-500'>
-                    {errors.newPw.message}
-                  </span>
+                  <FormErrorMessage
+                    fieldErrors={errors.newPw}
+                    className='mt-2'
+                  />
                 )}
               </div>
               <div className={fieldStyle}>
-                <span>새 비밀번호 확인</span>
+                <label htmlFor='confirmPw' className='text-14'>
+                  새 비밀번호 확인
+                </label>
                 <input
                   {...register('confirmPw', fieldRules.confirmPw)}
                   id='confirmPw'
@@ -60,9 +66,10 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
                   className={inputStyle}
                 />
                 {errors.confirmPw && (
-                  <span className='!text-12 mt-2 text-red-500'>
-                    {errors.confirmPw.message}
-                  </span>
+                  <FormErrorMessage
+                    fieldErrors={errors.confirmPw}
+                    className='mt-2'
+                  />
                 )}
               </div>
             </div>

--- a/src/pages/My/components/PasswordModal.tsx
+++ b/src/pages/My/components/PasswordModal.tsx
@@ -29,6 +29,7 @@ export default function PasswordModal({ isVisible, onClose }: EditModalProps) {
               type='button'
               className='absolute top-12 right-12'
               onClick={handleClose}
+              aria-label='닫기'
             >
               <X size={24} />
             </button>

--- a/src/pages/My/components/ProfileInfo.tsx
+++ b/src/pages/My/components/ProfileInfo.tsx
@@ -1,13 +1,11 @@
 import { UserInfo } from '@/types/user';
 
 export default function ProfileInfo({ user }: { user: UserInfo }) {
-  const bgColor = !user.imageUrl && 'bg-primary-300/5';
-
   return (
     <div className='flex flex-col gap-20'>
       <div className='flex items-center gap-16'>
         <div
-          className={`w-58 h-58 rounded-full overflow-hidden border-1 ${bgColor}`}
+          className={`w-58 h-58 rounded-full overflow-hidden border-1 bg-primary-300/5`}
         >
           {user.imageUrl && (
             <img

--- a/src/pages/My/components/ProfileInfo.tsx
+++ b/src/pages/My/components/ProfileInfo.tsx
@@ -31,22 +31,22 @@ export default function ProfileInfo({ user }: { user: UserInfo }) {
         계정 생성 일자: {user.createdAt.split('T')[0]}
       </span>
       <div className='[&_strong]:font-semibold [&>p]:pb-6'>
-        <p>
+        <p aria-label='회원 등급'>
           <strong>회원 등급:</strong> &nbsp;{user.role}
         </p>
-        <p>
+        <p aria-label='소속 학교'>
           <strong>소속 학교:</strong> &nbsp;{user.school}
         </p>
-        <p>
+        <p aria-label='학번'>
           <strong>학번:</strong> &nbsp;{user.studentId}
         </p>
-        <p>
+        <p aria-label='이메일'>
           <strong>Email:</strong> &nbsp;{user.email}
         </p>
-        <p>
+        <p aria-label='작성한 게시물 수'>
           <strong>작성한 게시물 수:</strong> &nbsp;{user.createPostCount}
         </p>
-        <p>
+        <p aria-label='작성한 댓글 수'>
           <strong>작성한 댓글 수: </strong>&nbsp;{user.createCommentCount}
         </p>
       </div>

--- a/src/pages/My/components/ProfileModal.test.tsx
+++ b/src/pages/My/components/ProfileModal.test.tsx
@@ -1,0 +1,177 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import customRender from '@/__test__/customRender';
+import { mockSelectFile } from '@/__test__/mockSelectFile';
+import * as Compressor from '@/libs/compressor';
+import userApi from '@/services/user';
+import { UserInfo } from '@/types/user';
+
+import ProfileModal from './ProfileModal';
+
+const user = userEvent.setup();
+
+const windowMock = {
+  scrollTo: vi.fn(),
+  alert: vi.fn(),
+};
+
+Object.assign(global, windowMock);
+
+const mockUserInfo: UserInfo = {
+  name: '김철수',
+  role: '학생',
+  email: 'qwer@test.com',
+  school: 'OO학교',
+  studentId: 12345,
+  imageUrl: 'https://example.com/test.jpg',
+  createdAt: '2024-11-12T11:57:03.906822',
+  createPostCount: 8,
+  createCommentCount: 7,
+};
+
+vi.mock('@/utils/convertURLtoFile', () => ({
+  convertURLtoFile: vi.fn(() =>
+    Promise.resolve(
+      new File(['dummy content'], 'test-image.webp', {
+        type: 'image/webp',
+      }),
+    ),
+  ),
+}));
+
+vi.mock('@/libs/compressor');
+
+const renderProfileModal = (userProps = mockUserInfo, onClose = vi.fn()) => {
+  customRender(<ProfileModal user={userProps} isVisible onClose={onClose} />);
+};
+
+const changeInputValue = async (label: string, value?: string) => {
+  const input = screen.getByLabelText(label);
+  await user.clear(input);
+  if (value) await user.type(input, value);
+};
+
+const clickButton = async (buttonText: string, type = 'text') => {
+  const button =
+    type === 'label'
+      ? screen.getByLabelText(buttonText)
+      : screen.getByRole('button', { name: buttonText });
+
+  await user.click(button);
+};
+
+describe('ProfileModal', () => {
+  test('이름, 학교, 학번, 프로필 이미지가 렌더링 되어야 한다.', () => {
+    renderProfileModal();
+
+    expect(screen.getByLabelText('이름')).toHaveValue('김철수');
+    expect(screen.getByLabelText('소속 학교')).toHaveValue('OO학교');
+    expect(screen.getByLabelText('학번')).toHaveValue(12345);
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com/test.jpg',
+    );
+  });
+
+  test('이름을 입력하지 않으면 오류 메시지를 렌더링한다.', async () => {
+    renderProfileModal();
+
+    await changeInputValue('이름');
+    expect(screen.getByText('이름을 입력하세요.')).toBeInTheDocument();
+  });
+
+  test('이름, 소속 학교의 글자수가 10자보다 많으면 오류 메시지를 렌더링한다.', async () => {
+    renderProfileModal();
+
+    await changeInputValue('이름', '김철수김철수김철수김철');
+    expect(
+      screen.getByText('이름은 최대 10자까지 입력할 수 있습니다.'),
+    ).toBeInTheDocument();
+
+    await changeInputValue('소속 학교', 'OOOOOOOO고등학교');
+    expect(
+      screen.getByText('학교는 최대 10자까지 입력할 수 있습니다.'),
+    ).toBeInTheDocument();
+  });
+
+  test('첨부한 이미지 파일이 2MB를 초과하면 오류 메시지를 띄운다.', async () => {
+    renderProfileModal({ ...mockUserInfo, imageUrl: '' });
+
+    // 5MB 이미지 파일 업로드 모의
+    const { select } = mockSelectFile(undefined, undefined, undefined, 5);
+    await select();
+    expect(window.alert).toHaveBeenCalledWith(
+      '이미지 파일의 크기는 2MB를 초과할 수 없습니다.',
+    );
+  });
+
+  test('이미지 삭제 버튼을 누르면 미리보기 이미지가 삭제된다.', async () => {
+    renderProfileModal();
+    expect(screen.queryByRole('img')).toBeInTheDocument();
+
+    await clickButton('프로필 이미지 삭제', 'label');
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  test('이미지 압축 및 첨부에 성공하면 미리보기 이미지를 보여준다.', async () => {
+    vi.spyOn(Compressor, 'compressImage').mockResolvedValueOnce(
+      new File(['dummy content'], 'compressed-image.webp', {
+        type: 'image/webp',
+      }),
+    );
+
+    renderProfileModal({ ...mockUserInfo, imageUrl: '' });
+
+    const { select } = mockSelectFile();
+    await select();
+    expect(screen.getByRole('img').getAttribute('src')).toBeTruthy();
+  });
+
+  test('이미지 압축에 실패하면 오류 메시지를 띄운다.', async () => {
+    vi.spyOn(Compressor, 'compressImage').mockRejectedValueOnce({});
+
+    renderProfileModal({ ...mockUserInfo, imageUrl: '' });
+
+    const { select } = mockSelectFile();
+    await select();
+    expect(window.alert).toHaveBeenCalledWith('이미지 압축에 실패했습니다.');
+  });
+
+  test('프로필 수정에 성공하면 성공 메시지를 띄운다.', async () => {
+    vi.spyOn(userApi, 'updateUserInfo').mockResolvedValueOnce({});
+
+    const mockOnClose = vi.fn();
+    renderProfileModal(mockUserInfo, mockOnClose);
+
+    await changeInputValue('소속 학교', '새로운학교');
+    await clickButton('변경사항 저장');
+
+    expect(window.alert).toHaveBeenCalledWith('수정이 완료되었습니다.');
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
+  test('프로필 수정에 실패하면 오류 메시지를 띄운다.', async () => {
+    vi.spyOn(userApi, 'updateUserInfo').mockRejectedValueOnce({});
+
+    renderProfileModal();
+
+    await changeInputValue('소속 학교', '새로운학교');
+    await clickButton('변경사항 저장');
+
+    expect(window.alert).toHaveBeenCalledWith('프로필 수정에 실패했습니다.');
+  });
+
+  test('취소 또는 닫기 버튼을 클릭하면 onClose가 실행된다.', async () => {
+    const mockOnClose = vi.fn();
+    renderProfileModal(mockUserInfo, mockOnClose);
+
+    await clickButton('취소');
+    expect(mockOnClose).toHaveBeenCalledOnce();
+
+    mockOnClose.mockClear();
+
+    await clickButton('닫기', 'name');
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/My/components/ProfileModal.tsx
+++ b/src/pages/My/components/ProfileModal.tsx
@@ -126,7 +126,7 @@ export default function ProfileModal({
           type='button'
           className='w-full h-45 px-24 text-15 
         text-primary-400 btn-white-pb font-semibold rounded-md'
-          onClick={onClose}
+          onClick={handleClose}
         >
           취소
         </button>

--- a/src/pages/My/components/ProfileModal.tsx
+++ b/src/pages/My/components/ProfileModal.tsx
@@ -22,6 +22,7 @@ export default function ProfileModal({
     handleFileChange,
     imagePreview,
     resetImageFile,
+    reset,
     errors,
     fieldRules,
     register,
@@ -33,6 +34,11 @@ export default function ProfileModal({
     resetImageFile();
   };
 
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
   return (
     <Modal isVisible={isVisible}>
       <Modal.Content>
@@ -40,7 +46,8 @@ export default function ProfileModal({
           <button
             type='button'
             className='absolute top-12 right-12'
-            onClick={onClose}
+            onClick={handleClose}
+            aria-label='닫기'
           >
             <X size={24} />
           </button>
@@ -114,7 +121,7 @@ export default function ProfileModal({
       </Modal.Content>
       <Modal.Actions direction='row'>
         <button
-          type='submit'
+          type='button'
           className='w-full h-45 px-24 text-15 
         text-primary-400 btn-white-pb font-semibold rounded-md'
           onClick={onClose}

--- a/src/pages/My/components/ProfileModal.tsx
+++ b/src/pages/My/components/ProfileModal.tsx
@@ -77,6 +77,7 @@ export default function ProfileModal({
                     />
                     <button
                       type='button'
+                      aria-label='프로필 이미지 삭제'
                       className='absolute top-4 right-4 rounded-full bg-white text-primary-400'
                       onClick={handleResetImage}
                     >
@@ -93,6 +94,7 @@ export default function ProfileModal({
                 type='file'
                 accept='image/*'
                 className='hidden'
+                data-testid='file-input'
               />
             </div>
             <div className={fieldStyle}>

--- a/src/pages/My/hooks/usePasswordForm.ts
+++ b/src/pages/My/hooks/usePasswordForm.ts
@@ -4,10 +4,7 @@ import userApi from '@/services/user';
 import { FieldRules } from '@/types';
 import { AuthFormProps } from '@/types/auth';
 
-interface IPasswordFormInput {
-  newPw: string;
-  confirmPw: string;
-}
+import { IPasswordFormInput } from '../types';
 
 export default function usePasswordForm({ onSuccess }: AuthFormProps) {
   const {

--- a/src/pages/My/hooks/useProfileForm.ts
+++ b/src/pages/My/hooks/useProfileForm.ts
@@ -24,9 +24,11 @@ interface UserProfileForm {
 export default function useProfileForm({ user, onClose }: UserProfileForm) {
   const {
     register,
+    reset,
     handleSubmit,
     formState: { errors },
   } = useForm<IProfileFormInput>({
+    mode: 'onChange',
     defaultValues: {
       name: user.name,
       school: user.school ?? '',
@@ -38,6 +40,7 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
 
   const fieldRules: FieldRules<IProfileFormInput> = {
     name: {
+      required: '이름을 입력하세요.',
       maxLength: {
         value: 10,
         message: '이름은 최대 10자까지 입력할 수 있습니다.',
@@ -70,6 +73,7 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
       setCompressedImageFile(compressedFile);
     } catch (error) {
       console.error('이미지 압축 실패: ', error);
+      alert('이미지 압축에 실패했습니다.');
     }
   };
 
@@ -130,6 +134,7 @@ export default function useProfileForm({ user, onClose }: UserProfileForm) {
     fieldRules,
     errors,
     register,
+    reset,
     onSubmit,
   };
 }

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -41,11 +41,25 @@ const mockUseGetProfile = vi.mocked(useGetProfile);
 const mockUseModal = vi.mocked(useModal);
 const mockNavigate = vi.mocked(Navigate);
 
+const mockProfileResponse = (user?: UserInfo, isLoading = false) => {
+  mockUseGetProfile.mockReturnValueOnce({
+    user,
+    isLoading,
+  });
+};
+
+const mockModalReturnValue = (isVisible = false, toggleModal = vi.fn()) => {
+  mockUseModal.mockReturnValueOnce({
+    isVisible,
+    toggleModal,
+  });
+};
+
 describe('마이페이지', () => {
-  // useGetProfile, useModal 기본 return 값 설정
+  // useModal 기본 return 값 설정
   beforeEach(() => {
     mockUseGetProfile.mockReturnValue({
-      user: undefined,
+      user: mockUserInfo,
       isLoading: false,
     });
     mockUseModal.mockReturnValue({
@@ -55,11 +69,7 @@ describe('마이페이지', () => {
   });
 
   test('로딩중이라면 로딩 컴포넌트를 렌더링한다.', () => {
-    mockUseGetProfile.mockReturnValueOnce({
-      user: undefined,
-      isLoading: true,
-    });
-
+    mockProfileResponse(undefined, true);
     customRender(<MyPage />);
 
     const loadingElements = screen.getAllByRole('status');
@@ -67,21 +77,13 @@ describe('마이페이지', () => {
   });
 
   test('로딩중이 아니고 user가 없으면 홈으로 redirect한다.', () => {
-    mockUseGetProfile.mockReturnValueOnce({
-      user: undefined,
-      isLoading: false,
-    });
+    mockProfileResponse(undefined, false);
     customRender(<MyPage />);
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/', replace: true }, {});
   });
 
   test('user가 존재하면 회원 정보를 렌더링한다.', async () => {
-    mockUseGetProfile.mockReturnValueOnce({
-      user: mockUserInfo,
-      isLoading: false,
-    });
-
     customRender(<MyPage />);
 
     // Skeleton이 없어야 한다.
@@ -103,23 +105,11 @@ describe('마이페이지', () => {
   });
 
   test('프로필 수정 버튼 클릭 시 toggleProfileModal이 실행되어야 한다.', () => {
-    mockUseGetProfile.mockReturnValueOnce({
-      user: mockUserInfo,
-      isLoading: false,
-    });
-
     const toggleProfileModal = vi.fn();
     const togglePwModal = vi.fn();
 
-    mockUseModal
-      .mockReturnValueOnce({
-        isVisible: false,
-        toggleModal: toggleProfileModal,
-      })
-      .mockReturnValueOnce({
-        isVisible: false,
-        toggleModal: togglePwModal,
-      });
+    mockModalReturnValue(false, toggleProfileModal);
+    mockModalReturnValue(false, togglePwModal);
 
     customRender(<MyPage />);
 
@@ -131,23 +121,11 @@ describe('마이페이지', () => {
   });
 
   test('비밀번호 변경 버튼 클릭 시 togglePwModal이 실행되어야 한다.', () => {
-    mockUseGetProfile.mockReturnValueOnce({
-      user: mockUserInfo,
-      isLoading: false,
-    });
-
     const toggleProfileModal = vi.fn();
     const togglePwModal = vi.fn();
 
-    mockUseModal
-      .mockReturnValueOnce({
-        isVisible: false,
-        toggleModal: toggleProfileModal,
-      })
-      .mockReturnValueOnce({
-        isVisible: false,
-        toggleModal: togglePwModal,
-      });
+    mockModalReturnValue(false, toggleProfileModal);
+    mockModalReturnValue(false, togglePwModal);
 
     customRender(<MyPage />);
 

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { Navigate } from 'react-router-dom';
+
+import customRender from '@/__test__/customRender';
+import useModal from '@/hooks/useModal';
+import { UserInfo } from '@/types/user';
+
+import useGetProfile from './hooks/useGetProfile';
+
+import MyPage from '.';
+
+const mockUserInfo: UserInfo = {
+  name: '김철수',
+  role: '학생',
+  email: 'qwer@test.com',
+  school: 'OO학교',
+  studentId: 12345,
+  imageUrl: 'https://example.com/test.jpg',
+  createdAt: '2024-11-12T11:57:03.906822',
+  createPostCount: 8,
+  createCommentCount: 7,
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    Navigate: vi.fn(() => null), // <Navigate /> 모킹
+  };
+});
+
+vi.mock('@/hooks/useModal', () => ({
+  default: vi.fn(),
+}));
+
+vitest.mock('./hooks/useGetProfile', () => ({
+  default: vi.fn(),
+}));
+
+const mockUseGetProfile = vi.mocked(useGetProfile);
+const mockUseModal = vi.mocked(useModal);
+const mockNavigate = vi.mocked(Navigate);
+
+describe('마이페이지', () => {
+  // useGetProfile, useModal 기본 return 값 설정
+  beforeEach(() => {
+    mockUseGetProfile.mockReturnValue({
+      user: undefined,
+      isLoading: false,
+    });
+    mockUseModal.mockReturnValue({
+      isVisible: false,
+      toggleModal: vi.fn(),
+    });
+  });
+
+  test('로딩중이라면 로딩 컴포넌트를 렌더링한다.', () => {
+    mockUseGetProfile.mockReturnValueOnce({
+      user: undefined,
+      isLoading: true,
+    });
+
+    customRender(<MyPage />);
+
+    const loadingElements = screen.getAllByRole('status');
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  test('로딩중이 아니고 user가 없으면 홈으로 redirect한다.', () => {
+    mockUseGetProfile.mockReturnValueOnce({
+      user: undefined,
+      isLoading: false,
+    });
+    customRender(<MyPage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/', replace: true }, {});
+  });
+
+  test('user가 존재하면 회원 정보를 렌더링한다.', async () => {
+    mockUseGetProfile.mockReturnValueOnce({
+      user: mockUserInfo,
+      isLoading: false,
+    });
+
+    customRender(<MyPage />);
+
+    // Skeleton이 없어야 한다.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // 회원 정보가 렌더링 되어야 한다.
+    expect(screen.getByText('계정 생성 일자: 2024-11-12')).toBeInTheDocument();
+    expect(screen.getByText('김철수')).toBeInTheDocument();
+    expect(screen.getByLabelText('회원 등급')).toHaveTextContent('학생');
+    expect(screen.getByLabelText('소속 학교')).toHaveTextContent('OO학교');
+    expect(screen.getByLabelText('학번')).toHaveTextContent('12345');
+    expect(screen.getByLabelText('이메일')).toHaveTextContent('qwer@test.com');
+    expect(screen.getByLabelText('작성한 게시물 수')).toHaveTextContent('8');
+    expect(screen.getByLabelText('작성한 댓글 수')).toHaveTextContent('7');
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com/test.jpg',
+    );
+  });
+
+  test('프로필 수정 버튼 클릭 시 toggleProfileModal이 실행되어야 한다.', () => {
+    mockUseGetProfile.mockReturnValueOnce({
+      user: mockUserInfo,
+      isLoading: false,
+    });
+
+    const toggleProfileModal = vi.fn();
+    const togglePwModal = vi.fn();
+
+    mockUseModal
+      .mockReturnValueOnce({
+        isVisible: false,
+        toggleModal: toggleProfileModal,
+      })
+      .mockReturnValueOnce({
+        isVisible: false,
+        toggleModal: togglePwModal,
+      });
+
+    customRender(<MyPage />);
+
+    const editButton = screen.getByText('정보 수정하기');
+    fireEvent.click(editButton);
+
+    expect(toggleProfileModal).toHaveBeenCalled();
+    expect(togglePwModal).not.toHaveBeenCalled();
+  });
+
+  test('비밀번호 변경 버튼 클릭 시 togglePwModal이 실행되어야 한다.', () => {
+    mockUseGetProfile.mockReturnValueOnce({
+      user: mockUserInfo,
+      isLoading: false,
+    });
+
+    const toggleProfileModal = vi.fn();
+    const togglePwModal = vi.fn();
+
+    mockUseModal
+      .mockReturnValueOnce({
+        isVisible: false,
+        toggleModal: toggleProfileModal,
+      })
+      .mockReturnValueOnce({
+        isVisible: false,
+        toggleModal: togglePwModal,
+      });
+
+    customRender(<MyPage />);
+
+    const editButton = screen.getByText('비밀번호 변경');
+    fireEvent.click(editButton);
+
+    expect(toggleProfileModal).not.toHaveBeenCalled();
+    expect(togglePwModal).toHaveBeenCalled();
+  });
+});

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/hooks/useModal', () => ({
   default: vi.fn(),
 }));
 
-vitest.mock('./hooks/useGetProfile', () => ({
+vi.mock('./hooks/useGetProfile', () => ({
   default: vi.fn(),
 }));
 

--- a/src/pages/My/types/index.ts
+++ b/src/pages/My/types/index.ts
@@ -8,3 +8,8 @@ export interface EditModalProps {
 export interface ProfileEditModalProps extends EditModalProps {
   user: UserInfo;
 }
+
+export interface IPasswordFormInput {
+  newPw: string;
+  confirmPw: string;
+}

--- a/src/utils/isEndWithConsonant.test.ts
+++ b/src/utils/isEndWithConsonant.test.ts
@@ -1,15 +1,15 @@
 import { isEndWithConsonant } from './isEndWithConsonant';
 
 describe('isEndWithConsonant', () => {
-  it('"맛집"의 마지막 글자는 받침이 있으므로 true를 반환해야 한다.', () => {
-    expect(isEndWithConsonant('맛집')).toBe(true);
+  test('"게시글"의 마지막 글자는 받침이 있으므로 true를 반환해야 한다.', () => {
+    expect(isEndWithConsonant('게시글')).toBe(true);
   });
 
-  it('"테스트"의 마지막 글자는 받침이 없으므로 false를 반환해야 한다.', () => {
+  test('"테스트"의 마지막 글자는 받침이 없으므로 false를 반환해야 한다.', () => {
     expect(isEndWithConsonant('테스트')).toBe(false);
   });
 
-  it('"값"의 마지막 글자는 받침이 있으므로 true를 반환해야 한다.', () => {
+  test('"값"의 마지막 글자는 받침이 있으므로 true를 반환해야 한다.', () => {
     expect(isEndWithConsonant('값')).toBe(true);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,9 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: './vitest.setup.ts',
+      coverage: {
+        reporter: ['text', 'html'],
+      },
     },
   };
 });


### PR DESCRIPTION
## 📝 개요

프로필 페이지 테스트 코드 작성

**테스트 대상**
- 프로필 페이지 (프로필 조회 및 인터랙션)
- 프로필 수정 모달
- 비밀번호 변경 모달

## 🚀 변경사항

- test coverage 확인을 위한 @vitest/coverage-v8 설치
- testing-library/user-event 설치
- 일부 요소에 role, aria-label 추가
- 프로필 수정 모달 닫을 때 form 초기화되지 않는 버그 수정

## 🔗 관련 이슈

#121

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
