### PR TITLE
feat: 회원 탈퇴 구현

### DIFF
--- a/src/pages/My/Leave.tsx
+++ b/src/pages/My/Leave.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Navigate } from 'react-router-dom';
+
+import Head from '@/components/Head';
+import useModal from '@/hooks/useModal';
+import useBoundStore from '@/stores';
+
+import LeaveModal from './components/LeaveModal';
+
+export default function Leave() {
+  const user = useBoundStore(state => state.user);
+  const [isAgreed, setIsAgreed] = useState(false);
+
+  const { isVisible: isLeaveModalVisible, toggleModal: toggleLeaveModal } =
+    useModal();
+
+  if (!user) return <Navigate to='/' replace />;
+
+  return (
+    <div className='w-full max-w-screen-sm m-auto px-24 py-60'>
+      <Head title='회원 탈퇴 | ABCDEdu' />
+      <h2 className='text-28 font-semibold mb-4'>회원 탈퇴</h2>
+      <p className='text-neutral-500'>
+        탈퇴하시기 전 안내 사항을 꼭 확인해 주세요.
+      </p>
+      <ul className='flex flex-col gap-16 py-50 list-disc pl-16'>
+        <li>
+          사용하고 계신 이메일(
+          <strong className='text-primary-400 font-semibold'>
+            {user.email}
+          </strong>
+          )은 탈퇴할 경우 재가입 및 복구가 불가능합니다.
+        </li>
+        <li>
+          탈퇴 후에도 작성한 게시물과 댓글은 그대로 남아 있습니다. (작성자 익명
+          처리)
+        </li>
+      </ul>
+      <div className='flex items-center gap-4 mb-60'>
+        <input
+          id='agree'
+          type='checkbox'
+          checked={isAgreed}
+          onChange={() => setIsAgreed(prev => !prev)}
+        />
+        <label htmlFor='agree' className='cursor-pointer'>
+          안내 사항을 모두 확인하였으며, 이에 동의합니다.
+        </label>
+      </div>
+      <button
+        className='block w-100 m-auto px-16 py-8 rounded-full 
+      bg-primary-400 text-white font-semibold disabled:bg-primary-400/15'
+        disabled={!isAgreed}
+        onClick={toggleLeaveModal}
+      >
+        탈퇴하기
+      </button>
+      <LeaveModal isVisible={isLeaveModalVisible} onClose={toggleLeaveModal} />
+    </div>
+  );
+}

--- a/src/pages/My/components/LeaveModal.tsx
+++ b/src/pages/My/components/LeaveModal.tsx
@@ -1,0 +1,56 @@
+import MessageModal from '@/components/MessageModal';
+import Modal from '@/components/Modal';
+
+import useLeave from '../hooks/useLeave';
+
+interface LeaveModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+export default function LeaveModal({ isVisible, onClose }: LeaveModalProps) {
+  const {
+    handleLeaveClick,
+    isMessageModalVisible,
+    messageModalType,
+    resultMessage,
+    handleMessageModalClose,
+  } = useLeave({ onSuccess: onClose });
+
+  return (
+    <>
+      <Modal size='xs' isVisible={isVisible}>
+        <Modal.Content>
+          <p className='text-center'>
+            회원 탈퇴 시 계정 복구가 불가능합니다.
+            <br />
+            정말 탈퇴하시겠습니까?
+          </p>
+        </Modal.Content>
+        <Modal.Actions direction='row'>
+          <button
+            className='w-full h-45 text-15 
+        text-primary-400 btn-white-pb font-semibold rounded-md'
+            onClick={onClose}
+          >
+            취소
+          </button>
+          <button
+            className='w-full h-45 bg-primary-400 text-15 
+        text-white font-semibold rounded-md'
+            onClick={handleLeaveClick}
+          >
+            탈퇴하기
+          </button>
+        </Modal.Actions>
+      </Modal>
+      <MessageModal
+        backdrop={false}
+        isVisible={isMessageModalVisible}
+        onClose={handleMessageModalClose}
+        type={messageModalType}
+        message={resultMessage}
+      />
+    </>
+  );
+}

--- a/src/pages/My/components/ProfileModal.tsx
+++ b/src/pages/My/components/ProfileModal.tsx
@@ -132,7 +132,7 @@ export default function ProfileModal({
         </button>
         <button
           type='submit'
-          className='w-full h-45 px-24 bg-primary-300 text-15 
+          className='w-full h-45 px-24 bg-primary-400 text-15 
         text-white font-semibold rounded-md disabled:bg-primary-400/15'
           onClick={onSubmit}
           disabled={isSubmitButtonDisabled}

--- a/src/pages/My/hooks/useLeave.ts
+++ b/src/pages/My/hooks/useLeave.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+import useLogout from '@/hooks/auth/useLogout';
+import useModal from '@/hooks/useModal';
+import authApi from '@/services/auth';
+
+export default function useLeave({ onSuccess }: { onSuccess: () => void }) {
+  const { handleLogout } = useLogout();
+
+  const { isVisible, toggleModal } = useModal();
+  const [messageModalType, setMessageModalType] = useState<'success' | 'error'>(
+    'success',
+  );
+  const [resultMessage, setResultMessage] = useState('');
+
+  const handleLeaveClick = async () => {
+    try {
+      await authApi.deleteAccount();
+      setMessageModalType('success');
+      setResultMessage(
+        '회원 탈퇴가 완료되었습니다.\n이용해 주셔서 감사합니다.',
+      );
+    } catch (error) {
+      console.log(error);
+      setMessageModalType('error');
+      setResultMessage('회원 탈퇴에 실패했습니다.');
+    } finally {
+      toggleModal();
+    }
+  };
+
+  const handleMessageModalClose = () => {
+    toggleModal();
+    onSuccess();
+    handleLogout();
+  };
+
+  return {
+    handleLeaveClick,
+    isMessageModalVisible: isVisible,
+    messageModalType,
+    resultMessage,
+    handleMessageModalClose,
+  };
+}

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
-import { Navigate } from 'react-router-dom';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
 
 import customRender from '@/__test__/customRender';
 import useModal from '@/hooks/useModal';
@@ -41,6 +41,16 @@ const mockUseGetProfile = vi.mocked(useGetProfile);
 const mockUseModal = vi.mocked(useModal);
 const mockNavigate = vi.mocked(Navigate);
 
+const renderMyPage = () => {
+  customRender(
+    <MemoryRouter initialEntries={['/mypage']}>
+      <Routes>
+        <Route path='/mypage' element={<MyPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
 const mockProfileResponse = (user?: UserInfo, isLoading = false) => {
   mockUseGetProfile.mockReturnValueOnce({
     user,
@@ -70,7 +80,7 @@ describe('마이페이지', () => {
 
   test('로딩중이라면 로딩 컴포넌트를 렌더링한다.', () => {
     mockProfileResponse(undefined, true);
-    customRender(<MyPage />);
+    renderMyPage();
 
     const loadingElements = screen.getAllByRole('status');
     expect(loadingElements.length).toBeGreaterThan(0);
@@ -78,13 +88,13 @@ describe('마이페이지', () => {
 
   test('로딩중이 아니고 user가 없으면 홈으로 redirect한다.', () => {
     mockProfileResponse(undefined, false);
-    customRender(<MyPage />);
+    renderMyPage();
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/', replace: true }, {});
   });
 
   test('user가 존재하면 회원 정보를 렌더링한다.', async () => {
-    customRender(<MyPage />);
+    renderMyPage();
 
     // Skeleton이 없어야 한다.
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
@@ -111,7 +121,7 @@ describe('마이페이지', () => {
     mockModalReturnValue(false, toggleProfileModal);
     mockModalReturnValue(false, togglePwModal);
 
-    customRender(<MyPage />);
+    renderMyPage();
 
     const editButton = screen.getByText('정보 수정하기');
     fireEvent.click(editButton);
@@ -127,7 +137,7 @@ describe('마이페이지', () => {
     mockModalReturnValue(false, toggleProfileModal);
     mockModalReturnValue(false, togglePwModal);
 
-    customRender(<MyPage />);
+    renderMyPage();
 
     const editButton = screen.getByText('비밀번호 변경');
     fireEvent.click(editButton);

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -1,4 +1,5 @@
-import { Navigate } from 'react-router-dom';
+import { CaretRight } from '@phosphor-icons/react';
+import { Link, Navigate } from 'react-router-dom';
 
 import Head from '@/components/Head';
 import useModal from '@/hooks/useModal';
@@ -47,6 +48,10 @@ export default function MyPage() {
           비밀번호 변경
         </button>
       </div>
+      <Link to='leave' className='flex-row-center w-fit mt-12 text-neutral-500'>
+        <span>회원탈퇴</span>
+        <CaretRight size={14} />
+      </Link>
     </div>
   );
 }

--- a/src/routes/PrivateRoutes.tsx
+++ b/src/routes/PrivateRoutes.tsx
@@ -5,6 +5,7 @@ import Layout from '@/components/Layout';
 import PrivateRoute from '@/components/PrivateRoute';
 
 const MyPage = lazy(() => import('@/pages/My'));
+const Leave = lazy(() => import('@/pages/My/Leave'));
 
 export const privateRoutes: RouteObject[] = [
   {
@@ -18,6 +19,10 @@ export const privateRoutes: RouteObject[] = [
       {
         path: '/mypage',
         element: <MyPage />,
+      },
+      {
+        path: '/mypage/leave',
+        element: <Leave />,
       },
     ],
   },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -28,6 +28,10 @@ class AuthApi {
   static async logout() {
     return del('/auth/logout');
   }
+
+  static async deleteAccount() {
+    return del('/members');
+  }
 }
 
 export default AuthApi;


### PR DESCRIPTION
## 📝 개요

회원 탈퇴 구현

https://github.com/user-attachments/assets/46ad2407-9fb6-4c0f-9cdd-d6393accbce8


## 🚀 변경사항

회원 탈퇴 Link 추가로 인해 프로필 페이지 테스트 코드 render에 MemoryRouter를 추가했습니다.

## 🔗 관련 이슈

#259 #121

## ➕ 기타

테스트 코드는 천천히 추가해보겠습니다 ㅎㅎ UI/UX 관련 의견 있으시면 말씀해 주세요!

<br/>