### PR TITLE
feat: 댓글 파일 첨부 구현

### DIFF
--- a/src/hooks/class/useSubClassFileHandler.ts
+++ b/src/hooks/class/useSubClassFileHandler.ts
@@ -14,9 +14,9 @@ function useSubClassFileHandler({ fileInfo }: UseFetchSubClassFileInfoProps) {
 
   const { fileData, isLoading, isError, error } = useSubClassFile({ fileId });
 
-  const isPdfFile =
-    !!fileData &&
-    getFileExtension(getFileName(fileData.filePresignedUrl)) === 'pdf';
+  const isPdfFile = fileData?.filePresignedUrl
+    ? getFileExtension(getFileName(fileData.filePresignedUrl)) === 'pdf'
+    : false;
 
   const canAccessFile = user?.role === '관리자' || user?.role === '학생';
   const canAccessTheoryFile = user?.role === '관리자';

--- a/src/libs/compressor.ts
+++ b/src/libs/compressor.ts
@@ -12,13 +12,15 @@ export async function compressImage(
   quality: number = 0.8,
 ): Promise<File> {
   return new Promise((resolve, reject) => {
+    const newFileName = file.name.replace(/\.[^/.]+$/, '.webp');
+
     new Compressor(file, {
       quality,
       mimeType: 'image/webp',
       maxWidth: 880,
       maxHeight: 620,
       success(result) {
-        const webPFile = new File([result], file.name, {
+        const webPFile = new File([result], newFileName, {
           type: 'image/webp',
         });
         resolve(webPFile);

--- a/src/libs/compressor.ts
+++ b/src/libs/compressor.ts
@@ -20,10 +20,8 @@ export async function compressImage(
       maxWidth: 880,
       maxHeight: 620,
       success(result) {
-        const webPFile = new File([result], newFileName, {
-          type: 'image/webp',
-        });
-        resolve(webPFile);
+        const compressedFile = new File([result], newFileName);
+        resolve(compressedFile);
       },
       error(err: Error) {
         console.error(err.message);

--- a/src/pages/Community/components/CommentCard.tsx
+++ b/src/pages/Community/components/CommentCard.tsx
@@ -1,4 +1,6 @@
+import { DownloadSimple } from '@phosphor-icons/react';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Comment } from '@/types/community';
 import { formatDate } from '@/utils/formatDate';
@@ -52,13 +54,24 @@ export default function CommentCard({
       {isEditMode ? (
         <CommentForm
           postId={postId}
-          commentId={comment.commentId}
           mode='edit'
-          defaultValue={comment.content}
+          comment={comment}
           toggleEditMode={toggleEditMode}
         />
       ) : (
-        <p>{comment.content}</p>
+        <>
+          <p>{comment.content}</p>
+          {comment.fileUrl && (
+            <Link
+              className='flex justify-between items-center mt-12 mb-4 p-12 
+              bg-primary-300/5 text-primary-300 text-14 rounded-lg w-130'
+              to={comment.fileUrl}
+            >
+              파일 다운받기
+              <DownloadSimple className='mt-1 block text-gray-600' size={17} />
+            </Link>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/pages/Community/components/CommentForm.tsx
+++ b/src/pages/Community/components/CommentForm.tsx
@@ -1,63 +1,33 @@
-import { FieldValues, useForm } from 'react-hook-form';
+import { PencilSimpleLine, Plus, Trash } from '@phosphor-icons/react';
 
-import useCommentMutation from '../hooks/useCommentMutation';
+import { Comment } from '@/types/community';
+
+import useCommmentForm from '../hooks/useCommentForm';
 
 interface CommentForm {
-  defaultValue?: string;
+  comment?: Comment;
   toggleEditMode?: () => void;
   mode?: 'create' | 'edit';
-  commentId?: number;
   postId: number;
 }
 
-interface ICommentForm {
-  content: string;
-}
-
 export default function CommentForm({
-  defaultValue,
+  comment,
   toggleEditMode,
   mode = 'create',
-  commentId,
   postId,
 }: CommentForm) {
-  const btnStyle = `rounded-[20px] text-14 ${mode === 'create' ? 'px-30 py-8' : 'px-16 py-4'}`;
+  const btnStyle = `rounded-[20px] ${mode === 'create' ? 'px-30 py-8' : 'px-16 py-4'}`;
 
-  const { createComment, updateComment } = useCommentMutation({ postId });
-  const { register, reset, handleSubmit, watch } = useForm<ICommentForm>({
-    defaultValues: { content: defaultValue ?? '' },
-  });
-
-  const content = watch('content', defaultValue);
-  const isButtonDisabled =
-    !content.trim() || createComment.isPending || updateComment.isPending;
-
-  const submitform = async (data: FieldValues) => {
-    // 댓글 수정
-    if (mode === 'edit' && commentId) {
-      updateComment.mutate(
-        { commentId, content: data.content },
-        {
-          onSuccess: () => {
-            if (toggleEditMode) toggleEditMode();
-          },
-        },
-      );
-      return;
-    }
-
-    // 댓글 생성
-    createComment.mutate(data.content, {
-      onSuccess: () => {
-        reset();
-      },
-    });
-  };
-
-  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    handleSubmit(submitform)();
-  };
+  const {
+    isButtonDisabled,
+    register,
+    handleFileChange,
+    handleDeleteFile,
+    handleClose,
+    fileName,
+    onSubmit,
+  } = useCommmentForm({ postId, comment, toggleEditMode });
 
   return (
     <form onSubmit={onSubmit} className={`${mode === 'edit' && 'pr-14'} mt-8`}>
@@ -66,7 +36,38 @@ export default function CommentForm({
         className='border-1 rounded-lg w-full py-6 px-8'
         placeholder='자신의 의견을 자유롭게 표현해 주세요.'
       />
-      <div className='flex justify-end gap-4'>
+
+      <div className='flex justify-end gap-12 text-14'>
+        <div className='flex justify-end items-center gap-14'>
+          <label
+            htmlFor='file'
+            className='flex-row-center gap-4 text-gray-700 px-12 mb-2 cursor-pointer'
+          >
+            {fileName ? (
+              <div className='py-5 flex items-center space-x-14'>
+                <p>{fileName}</p>
+                {mode === 'create' ? (
+                  <button onClick={handleDeleteFile}>
+                    <Trash size={18} />
+                  </button>
+                ) : (
+                  <PencilSimpleLine size={18} className='text-neutral-500' />
+                )}
+              </div>
+            ) : (
+              <>
+                <Plus weight='bold' className='text-primary-400' size={18} />
+                파일 업로드
+              </>
+            )}
+          </label>
+          <input
+            id='file'
+            type='file'
+            className='hidden'
+            onChange={handleFileChange}
+          />
+        </div>
         <button
           type='submit'
           className={`bg-primary-400 text-white ${btnStyle} disabled:bg-primary-400/15`}
@@ -74,10 +75,10 @@ export default function CommentForm({
         >
           {mode === 'create' ? '등록' : '완료'}
         </button>
-        {mode === 'edit' && toggleEditMode && (
+        {mode === 'edit' && (
           <button
             type='button'
-            onClick={toggleEditMode}
+            onClick={handleClose}
             className={`bg-white border-1 border-neutral-200 ${btnStyle}`}
           >
             취소

--- a/src/pages/Community/components/CommentForm.tsx
+++ b/src/pages/Community/components/CommentForm.tsx
@@ -2,7 +2,7 @@ import { PencilSimpleLine, Plus, Trash } from '@phosphor-icons/react';
 
 import { Comment } from '@/types/community';
 
-import useCommmentForm from '../hooks/useCommentForm';
+import useCommentForm from '../hooks/useCommentForm';
 
 interface CommentForm {
   comment?: Comment;
@@ -27,7 +27,7 @@ export default function CommentForm({
     handleClose,
     fileName,
     onSubmit,
-  } = useCommmentForm({ postId, comment, toggleEditMode });
+  } = useCommentForm({ postId, comment, toggleEditMode });
 
   return (
     <form onSubmit={onSubmit} className={`${mode === 'edit' && 'pr-14'} mt-8`}>

--- a/src/pages/Community/components/PostNavigation.tsx
+++ b/src/pages/Community/components/PostNavigation.tsx
@@ -39,7 +39,7 @@ interface PostNavigationProps {
 
 function PostNavigation({ category, prevPost, nextPost }: PostNavigationProps) {
   return (
-    <div className={'flex flex-col gap-10'}>
+    <div className={'flex flex-col gap-10 mt-60'}>
       <hr className='border-1 border-gray-300 w-full mt-20' />
       {nextPost && (
         <PostNavLink type={'다음'} category={category} postInfo={nextPost} />

--- a/src/pages/Community/hooks/useCommentForm.ts
+++ b/src/pages/Community/hooks/useCommentForm.ts
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { Comment } from '@/types/community';
+import { getFileName } from '@/utils/getFileName';
+
+import useCommentMutation from './useCommentMutation';
+
+interface ICommentFormInput {
+  content: string;
+}
+
+interface UseCommmentFormProps {
+  postId: number;
+  comment?: Comment;
+  toggleEditMode?: () => void;
+}
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024;
+
+export default function useCommmentForm({
+  postId,
+  comment,
+  toggleEditMode,
+}: UseCommmentFormProps) {
+  const { createComment, updateComment } = useCommentMutation({
+    postId,
+  });
+
+  const { register, setValue, watch, handleSubmit, reset } =
+    useForm<ICommentFormInput>({
+      defaultValues: {
+        content: comment?.content ?? '',
+      },
+    });
+
+  const [file, setFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState('');
+
+  const content = watch('content', comment?.content);
+
+  const isButtonDisabled =
+    !content.trim() || createComment.isPending || updateComment.isPending;
+
+  // 수정 후 다시 edit mode 전환 시, updated 된 데이터 fetch
+  useEffect(() => {
+    if (comment) {
+      setValue('content', comment.content);
+      setFileName(comment.fileUrl ? getFileName(comment.fileUrl) : '');
+    }
+  }, [comment, setValue]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputFile = e.target.files?.[0];
+    if (!inputFile) return;
+
+    if (inputFile.size > MAX_FILE_SIZE) {
+      alert('첨부파일은 100MB를 초과할 수 없습니다.');
+      e.target.value = '';
+      return;
+    }
+    setFile(inputFile);
+    setFileName(inputFile.name);
+  };
+
+  // 댓글 생성 중 첨부 파일 삭제
+  // (댓글 수정 시에는 첨부된 파일 삭제 불가, 파일 삭제하려면 댓글 삭제)
+  const handleDeleteFile = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setFile(null);
+    setFileName('');
+  };
+
+  const handleClose = () => {
+    if (toggleEditMode) toggleEditMode();
+    reset();
+    setFileName('');
+  };
+
+  const submitForm: SubmitHandler<ICommentFormInput> = async data => {
+    const formData = new FormData();
+    formData.append('content', data.content);
+    formData.append('file', file ?? '');
+
+    // 댓글 수정
+    if (comment) {
+      const postUpdateData = {
+        commentId: Number(comment.commentId),
+        form: formData,
+      };
+      updateComment.mutate(postUpdateData, {
+        onSuccess: () => {
+          if (toggleEditMode) toggleEditMode();
+          reset();
+          setFileName('');
+        },
+      });
+      return;
+    }
+
+    // 댓글 생성
+    createComment.mutate(formData, {
+      onSuccess: () => {
+        reset();
+        setFileName('');
+      },
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handleSubmit(submitForm)();
+  };
+
+  return {
+    isButtonDisabled,
+    register,
+    handleFileChange,
+    handleDeleteFile,
+    handleClose,
+    fileName,
+    onSubmit,
+  };
+}

--- a/src/pages/Community/hooks/useCommentForm.ts
+++ b/src/pages/Community/hooks/useCommentForm.ts
@@ -84,11 +84,11 @@ export default function useCommmentForm({
 
     // 댓글 수정
     if (comment) {
-      const postUpdateData = {
+      const commentUpdateData = {
         commentId: Number(comment.commentId),
         form: formData,
       };
-      updateComment.mutate(postUpdateData, {
+      updateComment.mutate(commentUpdateData, {
         onSuccess: () => {
           if (toggleEditMode) toggleEditMode();
           reset();

--- a/src/pages/Community/hooks/useCommentMutation.ts
+++ b/src/pages/Community/hooks/useCommentMutation.ts
@@ -6,30 +6,24 @@ export default function useCommentMutation({ postId }: { postId: number }) {
   const queryClient = useQueryClient();
 
   const createComment = useMutation({
-    mutationFn: (content: string) =>
-      communityApi.createComment(postId, content),
+    mutationFn: (form: FormData) => communityApi.createComment(postId, form),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] });
     },
     onError: error => {
-      alert('오류가 발생했습니다.');
+      alert('댓글 작성 중 오류가 발생했습니다.');
       console.log(error);
     },
   });
 
   const updateComment = useMutation({
-    mutationFn: ({
-      commentId,
-      content,
-    }: {
-      commentId: number;
-      content: string;
-    }) => communityApi.updateComment(commentId, content),
+    mutationFn: ({ commentId, form }: { commentId: number; form: FormData }) =>
+      communityApi.updateComment(commentId, form),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] });
     },
     onError: error => {
-      alert('오류가 발생했습니다.');
+      alert('댓글 수정 중 오류가 발생했습니다.');
       console.log(error);
     },
   });
@@ -41,7 +35,7 @@ export default function useCommentMutation({ postId }: { postId: number }) {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] });
     },
     onError: error => {
-      alert('오류가 발생했습니다.');
+      alert('댓글 삭제 중 오류가 발생했습니다.');
       console.log(error);
     },
   });

--- a/src/pages/Community/hooks/usePostForm.ts
+++ b/src/pages/Community/hooks/usePostForm.ts
@@ -16,14 +16,14 @@ interface IPostFormInput {
   commentAllow: boolean;
 }
 
-interface usePostFormProps {
+interface UsePostFormProps {
   post?: Post;
   onSuccess: () => void;
 }
 
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 
-export default function usePostForm({ post, onSuccess }: usePostFormProps) {
+export default function usePostForm({ post, onSuccess }: UsePostFormProps) {
   const {
     register,
     setValue,
@@ -71,7 +71,7 @@ export default function usePostForm({ post, onSuccess }: usePostFormProps) {
     if (!inputFile) return;
 
     if (inputFile.size > MAX_FILE_SIZE) {
-      alert('첨부파일은 20MB를 초과할 수 없습니다.');
+      alert('첨부파일은 100MB를 초과할 수 없습니다.');
       e.target.value = '';
       return;
     }

--- a/src/services/community.ts
+++ b/src/services/community.ts
@@ -41,12 +41,16 @@ class CommunityApi {
     });
   }
 
-  static async createComment(postId: number, content: string) {
-    return post(`/posts/${postId}/comments`, { content });
+  static async createComment(postId: number, form: FormData) {
+    return post(`/posts/${postId}/comments`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
   }
 
-  static async updateComment(commentId: number, content: string) {
-    return patch(`/comments/${commentId}`, { content });
+  static async updateComment(commentId: number, form: FormData) {
+    return patch(`/comments/${commentId}`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
   }
 
   static async deleteComment(postId: number, commentId: number) {

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -29,5 +29,6 @@ export interface Comment {
   writerName: string;
   writerEmail: string;
   content: string;
+  fileUrl: string | null;
   createdAt: string;
 }

--- a/src/utils/getFileName.ts
+++ b/src/utils/getFileName.ts
@@ -1,5 +1,7 @@
 export const getFileName = (url: string) => {
   const path = url.split('?')[0];
   const fileName = path.split('/').pop();
+
+  if (!fileName) throw new Error('파일 이름을 가져올 수 없습니다.');
   return fileName;
 };


### PR DESCRIPTION
## 📝 개요

댓글 파일 첨부 구현

![image](https://github.com/user-attachments/assets/ab41baf5-022e-4d51-8bd7-e81d91e6ee55)

**댓글(파일) 수정**

![image](https://github.com/user-attachments/assets/6af96f7a-6846-488b-ac1b-ec6491ad2d49)


이미 생성된 댓글에 첨부된 파일을 삭제하려면 댓글 자체를 삭제해야 합니다.

<br/>

## 🚀 변경사항

- `PostNavigation`과 댓글 영역 사이에 간격을 좀 더 크게 했습니다.
- `getFileName` 예외 처리 추가
- `getFileName` 예외 처리 추가 이후에 `useSubClassFileHandler` 테스트가 실패하는 문제가 있었습니다. fileData.filePresignedUrl이 undefined인 경우에도 함수가 호출되는 것 같아 isPdfFile 값을 수정했습니다. https://github.com/team-abcdedu/abcdedu-frontend/pull/279/commits/0c2ee9013260936e4531782b071ad8284274ad04

<br/>

## 🔗 관련 이슈

#272

<br/>

## ➕ 기타

<!-- reviewer가 알아야 할 추가적인 정보가 있다면 작성해주세요. -->
