### PR TITLE
Add survey list and dynamic survey route

### DIFF
--- a/src/pages/Survey/components/SurveyForm.tsx
+++ b/src/pages/Survey/components/SurveyForm.tsx
@@ -33,7 +33,7 @@ function SurveyForm({ surveyId, questions }: SurveyFormProps) {
       onSuccess: () => {
         reset();
         alert('설문이 제출되었습니다.');
-        navigate('/survey');
+        navigate('/surveys');
       },
       onError: error => {
         alert(

--- a/src/pages/Survey/index.tsx
+++ b/src/pages/Survey/index.tsx
@@ -1,4 +1,5 @@
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import AccessError from '@/components/ErrorBoundary/AccessError';
@@ -9,6 +10,7 @@ import useBoundStore from '@/stores';
 
 function Survey() {
   const { reset } = useQueryErrorResetBoundary();
+  const { surveyId } = useParams();
   const user = useBoundStore(state => state.user);
 
   if (!user) {
@@ -31,7 +33,7 @@ function Survey() {
         }
         onReset={reset}
       >
-        <SurveyLayout surveyId={1} />
+        <SurveyLayout surveyId={Number(surveyId) || 1} />
       </ErrorBoundary>
     </div>
   );

--- a/src/pages/SurveyList/index.tsx
+++ b/src/pages/SurveyList/index.tsx
@@ -1,0 +1,30 @@
+import { Link, useSearchParams } from 'react-router-dom';
+import Head from '@/components/Head';
+import Pagination from '@/components/Pagination';
+import useSurveyList from '@/hooks/survey/useSurveyList';
+
+function SurveyList() {
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
+  const { surveyList, totalElements, isLoading, isError } = useSurveyList({ page });
+
+  return (
+    <div className={'flex flex-col mt-20 gap-20 items-center'}>
+      <Head title={'설문 목록 | ABCDEdu'} />
+      {isError && <div>데이터를 불러오는 중 오류가 발생했습니다.</div>}
+      {isLoading && <div>데이터를 불러오는 중입니다.</div>}
+      <ul className={'w-full flex flex-col gap-10'}>
+        {surveyList.map(item => (
+          <li key={item.id} className={'border-b pb-10'}>
+            <Link to={`/survey/${item.id}`} className={'text-primary-400 underline'}>
+              {item.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Pagination currentPage={page} totalElements={totalElements} />
+    </div>
+  );
+}
+
+export default SurveyList;

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -19,6 +19,7 @@ const PostDetail = lazy(() => import('@/pages/Community/PostDetail'));
 const Homework = lazy(() => import('@/pages/Homework'));
 
 const Survey = lazy(() => import('@/pages/Survey'));
+const SurveyList = lazy(() => import('@/pages/SurveyList'));
 
 const Contact = lazy(() => import('@/pages/Contact'));
 
@@ -80,7 +81,11 @@ export const publicRoutes: RouteObject[] = [
         element: <Homework />,
       },
       {
-        path: '/survey',
+        path: '/surveys',
+        element: <SurveyList />,
+      },
+      {
+        path: '/survey/:surveyId',
         element: <Survey />,
       },
     ],


### PR DESCRIPTION
## Summary
- add a new survey list page
- make survey page use dynamic `surveyId`
- redirect to survey list after submitting
- update public routes to include new pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7b3c1fb8832f9162d708a5d5c18b